### PR TITLE
Add PCGExConstants to project

### DIFF
--- a/Source/PCGExtendedToolkit/Private/Constants/PCGExConstants.cpp
+++ b/Source/PCGExtendedToolkit/Private/Constants/PCGExConstants.cpp
@@ -1,0 +1,193 @@
+﻿// Copyright 2024 Edward Boucher and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#include "Constants/PCGExConstants.h"
+#include "PCGContext.h"
+#include "PCGParamData.h"
+#include "Elements/Metadata/PCGMetadataElementCommon.h"
+
+#if WITH_EDITOR
+FName UPCGExConstantsSettings::GetDefaultNodeName() const {
+	return FName("Constant");
+}
+
+FLinearColor UPCGExConstantsSettings::GetNodeTitleColor() const {
+	return FLinearColor(0.2, 0.2, 0.2, 1.0);
+}
+
+FText UPCGExConstantsSettings::GetDefaultNodeTitle() const {
+	return FText::FromString("PGCEx | Constant");
+}
+
+TArray<FPCGPreConfiguredSettingsInfo> UPCGExConstantsSettings::GetPreconfiguredInfo() const {
+	return PCGMetadataElementCommon::FillPreconfiguredSettingsInfoFromEnum<EConstantListID>();
+}
+#endif
+
+FString UPCGExConstantsSettings::GetAdditionalTitleInformation() const {
+	if (const UEnum* EnumPtr = StaticEnum<EConstantListID>()) {
+		return EnumPtr->GetDisplayNameTextByValue(static_cast<int64>(ConstantList)).ToString();
+	};
+	return FString();
+}
+
+void UPCGExConstantsSettings::ApplyPreconfiguredSettings(const FPCGPreConfiguredSettingsInfo& PreconfigureInfo) {
+	if (const UEnum* EnumPtr = StaticEnum<EConstantListID>()) {
+		if (EnumPtr->IsValidEnumValue(PreconfigureInfo.PreconfiguredIndex)) {
+			ConstantList = static_cast<EConstantListID>(PreconfigureInfo.PreconfiguredIndex);
+		}
+	}
+}
+
+TArray<FPCGPinProperties> UPCGExConstantsSettings::OutputPinProperties() const {
+	
+	TArray<FPCGPinProperties> Out;
+
+	// Boolean pins
+	if (ConstantList == EConstantListID::Booleans) {
+		for (const auto Constant : PCGExConstants::Booleans) {
+			auto Pin = Out.Emplace_GetRef(Constant.Name, EPCGDataType::Param, true, false);
+		}
+		return Out;
+	}
+
+	// Vector pins (just axes for now)
+	if (ConstantList == EConstantListID::Vectors) {
+		auto ConstantsList = GetVectorConstantList(ConstantList);
+		for (const auto Constant : ConstantsList.Constants) {
+			auto Pin = Out.Emplace_GetRef(Constant.Name, EPCGDataType::Param, true, false);
+		}
+		return Out;
+	}
+	
+	// Numerics
+	auto ConstantsList = GetNumericConstantList(ConstantList);
+	for (const auto Constant : ConstantsList.Constants) {
+		auto Pin = Out.Emplace_GetRef(Constant.Name, EPCGDataType::Param, true, false);
+	}
+	
+
+	return Out;
+}
+
+FPCGElementPtr UPCGExConstantsSettings::CreateElement() const {
+	return MakeShared<FPCGConstantsElement>();
+}
+
+FConstantDescriptorList<double> UPCGExConstantsSettings::GetNumericConstantList(EConstantListID ConstantList) {
+	return PCGExConstants::Numbers.ExportedConstants[static_cast<uint8>(ConstantList)];
+}
+
+FConstantDescriptorList<FVector> UPCGExConstantsSettings::GetVectorConstantList(EConstantListID ConstantList) {
+	return PCGExConstants::Vectors.ExportedConstants[0];
+}
+
+bool FPCGConstantsElement::ExecuteInternal(FPCGContext* Context) const {
+
+	check (Context);
+
+	const UPCGExConstantsSettings* Settings = Context->GetInputSettings<UPCGExConstantsSettings>();
+	check(Settings);
+
+	// Boolean constant outputs
+	if (Settings->ConstantList == EConstantListID::Booleans) {
+		for (const auto Constant : PCGExConstants::Booleans) {
+			UPCGParamData* OutputData = FPCGContext::NewObject_AnyThread<UPCGParamData>(Context);
+			check(OutputData && OutputData->Metadata);
+
+			auto Attrib = OutputData->Metadata->CreateAttribute<bool>(Constant.Name, Constant.Value, true, false);
+			OutputData->Metadata->AddEntry();
+			auto Value = Constant.Value;
+			Attrib->AddValue(Value);
+		
+			FPCGTaggedData& NewData = Context->OutputData.TaggedData.Emplace_GetRef();
+			NewData.Data = OutputData;
+			NewData.Pin = Constant.Name;
+		}
+	}
+	
+	// Vector constant output
+	else if (Settings->ConstantList == EConstantListID::Vectors) {
+		auto ConstantsList = UPCGExConstantsSettings::GetVectorConstantList(Settings->ConstantList);
+		for (const auto Constant : ConstantsList.Constants) {
+			UPCGParamData* OutputData = FPCGContext::NewObject_AnyThread<UPCGParamData>(Context);
+			check(OutputData && OutputData->Metadata);
+
+			auto Attrib = OutputData->Metadata->CreateAttribute<FVector>(Constant.Name, Constant.Value, true, false);
+			OutputData->Metadata->AddEntry();
+
+			auto Value = Constant.Value;
+
+			if (Settings->NegateOutput) {
+				Value = Value * -1.0;
+			}
+
+			Attrib->AddValue(Value * Settings->CustomMultiplier);
+		
+			FPCGTaggedData& NewData = Context->OutputData.TaggedData.Emplace_GetRef();
+			NewData.Data = OutputData;
+			NewData.Pin = Constant.Name;
+		}
+	}
+	
+	// Numeric constant output
+	else {
+		auto ConstantsList = UPCGExConstantsSettings::GetNumericConstantList(Settings->ConstantList);
+		for (const auto Constant : ConstantsList.Constants) {
+			UPCGParamData* OutputData = FPCGContext::NewObject_AnyThread<UPCGParamData>(Context);
+			check(OutputData && OutputData->Metadata);
+			
+			auto Value = Constant.Value;
+
+			if (Settings->NegateOutput) {
+				Value = Value * -1.0;
+			}
+			
+			if (Settings->OutputReciprocal) {
+				if (!FMath::IsNearlyZero(Value)) {
+					Value = 1.0 / Value;
+				}
+				else {
+					Value = 0.0;
+				}
+				
+			}
+			
+			Value = Value * Settings->CustomMultiplier;
+
+			FPCGMetadataAttribute<double>* DoubleAttrib = nullptr;
+			FPCGMetadataAttribute<float>* FloatAttrib = nullptr;
+			FPCGMetadataAttribute<int>* Int32Attrib = nullptr;
+			FPCGMetadataAttribute<int64>* Int64Attrib = nullptr;
+
+			switch (Settings->NumericOutputType) {
+				case ENumericOutput::Double:
+					DoubleAttrib = OutputData->Metadata->CreateAttribute<double>(Constant.Name, Value, true, false);
+					DoubleAttrib->AddValue(Value);
+					break;
+			
+				case ENumericOutput::Float:
+					FloatAttrib = OutputData->Metadata->CreateAttribute<float>(Constant.Name, Value, true, false);
+					FloatAttrib->AddValue(Value);
+					break;
+
+				case ENumericOutput::Int32:
+					Int32Attrib = OutputData->Metadata->CreateAttribute<int32>(Constant.Name, FMath::RoundToInt32(Value), true, false);
+					Int32Attrib->AddValue(FMath::RoundToInt32(Value));
+					break;
+
+				case ENumericOutput::Int64:
+					Int64Attrib = OutputData->Metadata->CreateAttribute<int64>(Constant.Name, FMath::RoundToInt64(Value), true, false);
+					Int64Attrib->AddValue(FMath::RoundToInt64(Value));
+					break;
+			}
+			
+			OutputData->Metadata->AddEntry();
+			FPCGTaggedData& NewData = Context->OutputData.TaggedData.Emplace_GetRef();
+			NewData.Data = OutputData;
+			NewData.Pin = Constant.Name;
+		}
+	}
+	
+	return true;
+}

--- a/Source/PCGExtendedToolkit/Public/Constants/PCGExConstants.h
+++ b/Source/PCGExtendedToolkit/Public/Constants/PCGExConstants.h
@@ -1,0 +1,73 @@
+﻿// Copyright 2024 Edward Boucher and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+#include "PCGSettings.h"
+#include "PCGExConstantsDefinitions.h"
+#include "PCGExConstants.generated.h"
+
+UENUM(BlueprintType) enum class ENumericOutput : uint8 {
+	Double,
+	Float,
+	Int32,
+	Int64,
+};
+
+UCLASS(BlueprintType, ClassGroup=(Procedural))
+class UPCGExConstantsSettings : public UPCGSettings {
+public:
+	GENERATED_BODY()
+
+#if WITH_EDITOR
+	virtual FName GetDefaultNodeName() const override;
+	virtual FLinearColor GetNodeTitleColor() const override;
+	virtual FText GetDefaultNodeTitle() const override;
+	virtual EPCGSettingsType GetType() const override { return EPCGSettingsType::Param; }
+	virtual bool OnlyExposePreconfiguredSettings() const override { return true; };
+	virtual bool CanUserEditTitle() const override { return false; }
+	virtual bool HasFlippedTitleLines() const override { return true; }
+	virtual TArray<FPCGPreConfiguredSettingsInfo> GetPreconfiguredInfo() const override;
+#endif
+	
+	virtual FString GetAdditionalTitleInformation() const override;
+	virtual void ApplyPreconfiguredSettings(const FPCGPreConfiguredSettingsInfo& PreconfigureInfo) override;
+
+	// Used by the preconfigured settings to load the right constants
+	UPROPERTY(BlueprintReadWrite) EConstantListID ConstantList;
+	
+	// Export the negative of the constant instead of the constant itself
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(EditCondition="ConstantList!=EConstantListID::Booleans", EditConditionHides))
+	bool NegateOutput = false;
+
+	// Output 1/x instead of x (e.g. 2 becomes 1/2)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(EditCondition="ConstantList!=EConstantListID::Booleans && ConstantList != EConstantListID::Vectors", EditConditionHides))
+	bool OutputReciprocal  = false;
+
+	// Apply a custom (constant, numeric) multiplier to the output
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(EditCondition="ConstantList!=EConstantListID::Booleans", EditConditionHides))
+	double CustomMultiplier = 1.0;
+
+	// Cast to a specific type (double will be used by default)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(EditCondition="ConstantList != EConstantListID::Booleans && ConstantList != EConstantListID::Vectors", EditConditionHides)) 
+	ENumericOutput NumericOutputType;
+
+protected:
+	virtual TArray<FPCGPinProperties> InputPinProperties() const override { return {}; }
+	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
+	virtual FPCGElementPtr CreateElement() const override;
+
+public:
+	static FConstantDescriptorList<double> GetNumericConstantList(EConstantListID ConstantList);
+	static FConstantDescriptorList<FVector> GetVectorConstantList(EConstantListID ConstantList);
+	
+	
+};
+
+class FPCGConstantsElement : public IPCGElement {
+protected:
+	virtual bool ExecuteInternal(FPCGContext* Context) const override;
+
+public:
+	virtual bool IsCacheable(const UPCGSettings* InSettings) const override { return true; }
+	
+};

--- a/Source/PCGExtendedToolkit/Public/Constants/PCGExConstantsDefinitions.h
+++ b/Source/PCGExtendedToolkit/Public/Constants/PCGExConstantsDefinitions.h
@@ -1,0 +1,135 @@
+﻿// Copyright 2024 Edward Boucher and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+#include "CoreMinimal.h"
+
+template <typename T>
+struct FTypedConstantDescriptor {
+	FName Name;
+	T Value;
+};
+
+template <typename T>
+struct FConstantDescriptorList {
+	FName GroupName;
+	TArray<FTypedConstantDescriptor<T>> Constants;
+};
+
+template <typename T>
+struct FConstantDescriptorListGroup {
+	FName DisplayName; // Not currently needed, but helps identify each in the namespace below
+	TArray<FConstantDescriptorList<T>> ExportedConstants;
+};
+
+// An enum used to identify the constants in the namespace below. This is perhaps a slightly messy way of doing things,
+// but it means we can use PCGMetadataElementCommon::FillPreconfiguredSettingsInfoFromEnum to create different nodes
+// for each.
+UENUM(BlueprintType) enum class EConstantListID : uint8 {
+
+	// Numeric constants
+	// These go before the others, as there's more of them, and that way we can just access them by index.
+	ZeroAndOne = 0 UMETA(DisplayName="0 and 1"),
+	MinusOne UMETA(DisplayName="-1"),
+	Twos UMETA(DisplayName="0.5 and 2"),
+	Tens UMETA(DisplayName="Powers of 10"),
+	Irrationals,
+	Angles,
+	Zero UMETA(DisplayName="0"),
+    One UMETA(DisplayName="1"),
+	
+	// Vectors (for now just the axes)
+	Vectors,
+
+	// Booleans
+	Booleans UMETA(DisplayName="True and False"),
+};
+ENUM_CLASS_FLAGS(EConstantListID)
+
+namespace PCGExConstants {
+
+	inline FConstantDescriptorListGroup<double> Numbers = {
+		"Numeric Constants",
+		{
+			{
+				"Zero and One",
+				
+				{
+					{"0", 0.0 },
+					{"1", 1.0 }
+				}
+			},
+			{
+				"Minus One",
+				{ {"-1", -1.0 } }	
+			},
+			{
+				"Twos",
+				{
+					{"Half", 0.5 },
+					{"2", 2.0 }
+				}
+			},
+			{
+				"Tens",
+				{
+					{ "10", 10.0},
+					{"100", 100.0},
+					{"1000", 1000.0},
+				}
+			},
+			{
+				"Irrationals",
+				{
+				{"Pi", DOUBLE_PI },
+				{"Tau", DOUBLE_PI * 2.0 },
+				{"E", DOUBLE_EULERS_NUMBER },
+				{"Root 2", DOUBLE_UE_SQRT_2 },
+				{"Golden Ratio", UE_DOUBLE_GOLDEN_RATIO }
+				}
+			},
+			{
+				"Angles",
+				
+				{
+					{"90", 90.0},
+					{"180", 180.0},
+					{"270", 270.0},
+					{"360", 360.0},
+					{"45", 45.0}
+				}
+			},
+			{
+				"Zero",
+				{{"0", 0.0} }
+			},
+			{
+            	"One",
+            	{{"1", 1.0} }
+            }
+			
+			
+		}
+	};
+
+	inline FConstantDescriptorListGroup<FVector> Vectors {
+		"Vector Constants",
+		{
+			{
+				"Axes",
+				
+				{
+					{"Up", FVector::UpVector },
+					{"Right", FVector::RightVector },
+					{"Forward", FVector::ForwardVector }
+				}
+			}
+		}
+	};
+	
+	inline TArray<FTypedConstantDescriptor<bool>> Booleans = {
+	    {"True", true },
+	    {"False", false }
+	};
+
+}


### PR DESCRIPTION
Adds nodes that expose an attribute containing a constant value, so you don't to configure a 'create attribute' node every time you want a 0 or the up vector.

Nodes included:

Booleans (true and false)
0
1
0 and 1
0.5 and 2
Powers of 10
Irrationals (Pi, E, Golden Ratio etc)
Angles (90, 180, 270, 360, 45)
Vector Axes (Up, Right, Forward)

Numeric values and vectors can optionally be scaled by a constant value and negated by selecting the relevant checkbox; numeric values that aren't 0 can also output their reciprocal (1/x)

Numeric values are output as double by default, but can be configured to output float, int32 and int64 as well.

No macros were used (well, created) in the making of this pull request. Also we have our code formatting set up differently, so you may want to run your own linter...