### PR TITLE
Fix enum constant value output attribute name being ignored

### DIFF
--- a/Source/PCGExtendedToolkit/Private/Constants/PCGExConstantEnum.cpp
+++ b/Source/PCGExtendedToolkit/Private/Constants/PCGExConstantEnum.cpp
@@ -265,7 +265,7 @@ void FPCGExConstantEnumElement::StageEnumValuesSeparatePins(
 
 		if (Settings->OutputEnumValues)
 		{
-			ValueAttrib = OutputData->Metadata->CreateAttribute<int64>(PCGExConstantEnumConstants::ValueOutputAttribute, 0, true, false);
+			ValueAttrib = OutputData->Metadata->CreateAttribute<int64>(Settings->ValueOutputAttribute, 0, true, false);
 		}
 
 		const auto Entry = OutputData->Metadata->AddEntry();


### PR DESCRIPTION
Forgot to update this when I added the value output names. 