### PR TITLE
Fix compilation on mac

### DIFF
--- a/Source/PCGExtendedToolkit/Public/Data/PCGExDataTag.h
+++ b/Source/PCGExtendedToolkit/Public/Data/PCGExDataTag.h
@@ -7,6 +7,7 @@
 #include "UObject/Object.h"
 
 #include "PCGExMacros.h"
+#include "PCGExHelpers.h"
 #include "Kismet/KismetStringLibrary.h"
 
 //#include "Data/PCGExDataTag.generated.h"

--- a/Source/PCGExtendedToolkit/Public/Misc/Pickers/PCGExPicker.h
+++ b/Source/PCGExtendedToolkit/Public/Misc/Pickers/PCGExPicker.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "PCGEx.h"
 #include "PCGExPicker.generated.h"
 
 namespace PCGExPicker


### PR DESCRIPTION
Compilation on Mac / Xcode fails in v0.58 due to some unknown type names. These includes fixes it. Cheers! 