### PR TITLE
Fixed some unexpected behaviors on DiscardByPointCount and PointsToBounds

### DIFF
--- a/Source/PCGExtendedToolkit/Private/Misc/PCGExDiscardByPointCount.cpp
+++ b/Source/PCGExtendedToolkit/Private/Misc/PCGExDiscardByPointCount.cpp
@@ -1,4 +1,5 @@
 ﻿// Copyright 2025 Timothé Lapetite and contributors
+// * 24/02/25 Omer Salomon Fixed - Made the count condition for discarding to be inclusive on MaxPointCount (to fit the comment).
 // Released under the MIT license https://opensource.org/license/MIT/
 
 #include "Misc/PCGExDiscardByPointCount.h"
@@ -46,7 +47,7 @@ bool FPCGExDiscardByPointCountElement::ExecuteInternal(FPCGContext* InContext) c
 		for (const TSharedPtr<PCGExData::FPointIO>& PointIO : Context->MainPoints->Pairs)
 		{
 			PointIO->bAllowEmptyOutput = Settings->bAllowEmptyOutputs;
-			if (!FMath::IsWithin(PointIO->GetNum(), Min, Max))
+			if (!FMath::IsWithinInclusive(PointIO->GetNum(), Min, Max))
 			{
 				PointIO->OutputPin = PCGExDiscardByPointCount::OutputDiscardedLabel;
 			}

--- a/Source/PCGExtendedToolkit/Public/Data/Blending/PCGExBlendModes.h
+++ b/Source/PCGExtendedToolkit/Public/Data/Blending/PCGExBlendModes.h
@@ -1,6 +1,6 @@
 ﻿// Copyright 2025 Timothé Lapetite and contributors
+// * 24/02/25 Omer Salomon Changed - Div(const FQuat& A, const double Divider) now converts FQuat to FRotator and calls Div on that.
 // Released under the MIT license https://opensource.org/license/MIT/
-
 
 #pragma once
 
@@ -480,8 +480,7 @@ namespace PCGExBlend
 	template <typename CompilerSafety = void>
 	FORCEINLINE static FQuat Div(const FQuat& A, const double Divider)
 	{
-		const double R = 1.0 / Divider;
-		return FQuat(A.X * R, A.Y * R, A.Z * R, A.W * R).GetNormalized();
+		return Div(A.Rotator(), Divider).Quaternion();
 	}
 
 	template <typename T>


### PR DESCRIPTION
On DiscardByPointCount:
The comment on MaxPointCount suggests that the output is kept if the number of points is "more than", so made the condition in the if statement inclusive to fit the comment.

On PointsToBounds:
I found that Average blend mode didn't work for rotations. The output rotation was actually the sum of all rotations. 
Sure enough, i found that the Div(const FQuat& A, const double Divider) function that is called after summing the rotation quaternions to complete the blend doesn't actually change anything mathematically.
Not sure the change I made is the intended one, but I based it on line 122 in the same file:
`return Add(A.Rotator(), B.Rotator()).Quaternion();`
That line does the sum for the blend.