### PR TITLE
Explicit logical op precedence required by Clang

### DIFF
--- a/Source/PCGExtendedToolkit/Private/Graph/PCGExClusterUtils.cpp
+++ b/Source/PCGExtendedToolkit/Private/Graph/PCGExClusterUtils.cpp
@@ -173,7 +173,7 @@ namespace PCGExClusterUtils
 			if (ProblemsTracker[i] <= 0) { continue; }
 
 			const FProblem& Problem = EProblemLogs[static_cast<EProblem>(i)];
-			if ((bSkipTrivial && !Problem.Get<0>()) || bSkipImportant && Problem.Get<0>()) { continue; }
+			if ((bSkipTrivial && !Problem.Get<0>()) || (bSkipImportant && Problem.Get<0>())) { continue; }
 
 			PCGE_LOG_C(Warning, GraphAndLog, InContext, Problem.Get<1>());
 		}


### PR DESCRIPTION
Clang does not allow implied precedence of && before || in logical operations. Added parentheses to prevent compiler error.