### PR TITLE
Logical OR requires explicit precedence on Linux

### DIFF
--- a/Source/PCGExtendedToolkit/Private/Transform/PCGExTransform.cpp
+++ b/Source/PCGExtendedToolkit/Private/Transform/PCGExTransform.cpp
@@ -25,7 +25,7 @@ bool FPCGExSocketFitDetails::Init(const TSharedPtr<PCGExData::FFacade>& InFacade
 {
 	if (!bEnabled ||
 		(SocketNameInput == EPCGExInputValueType::Constant && SocketName.IsNone()) ||
-		SocketNameInput == EPCGExInputValueType::Attribute && SocketNameAttribute.IsNone())
+		(SocketNameInput == EPCGExInputValueType::Attribute && SocketNameAttribute.IsNone()))
 	{
 		bMutate = false;
 		return true;


### PR DESCRIPTION
Failed to compile before change. After change, here is the result on the build server:

`Reading filter rules from /usr/local/packages/PCGExtendedToolkit/HostProject/Plugins/PCGExtendedToolkit/Config/FilterPlugin.ini
Loading FilterPluginLinux.ini
BUILD SUCCESSFUL
AutomationTool executed for 0h 35m 36s
AutomationTool exiting with ExitCode=0 (Success)`

I'll send the full log if requested.