### PR TITLE
Use Unreal's PCG seed functions instead of using Perlin Noise

### DIFF
--- a/Source/PCGExtendedToolkit/Private/PCGExRandom.cpp
+++ b/Source/PCGExtendedToolkit/Private/PCGExRandom.cpp
@@ -6,6 +6,7 @@
 #include "PCGComponent.h"
 #include "PCGExMath.h"
 #include "PCGSettings.h"
+#include "Helpers/PCGHelpers.h"
 
 namespace PCGExRandom
 {
@@ -60,9 +61,8 @@ namespace PCGExRandom
 	}
 
 	int ComputeSpatialSeed(const FVector& Origin, const FVector& Offset)
-	{
-		return static_cast<int>(PCGExMath::Remap(
-			FMath::PerlinNoise3D(PCGExMath::Tile(Origin * 0.001 + Offset, FVector(-1), FVector(1))),
-			-1, 1, MIN_int32, MAX_int32));
+	{		
+		return PCGHelpers::ComputeSeed(PCGHelpers::ComputeSeedFromPosition(Origin), 
+									   PCGHelpers::ComputeSeedFromPosition(Offset));
 	}
 }


### PR DESCRIPTION
This makes PCGEx seed computation deterministic between computers, and also quantizes seed based positions to 1cm resolution. (I suspect tiny floating point differences were causing the different seeds in the first place)

It should also be loads cheaper than FMath::PerlinNoise3D too which is a bonus. (Only a few instructions per point as opposed to quite a complex function), and if Epic decides to improve the seed function we get that too.

I'm not entirely sure if you want to just add Origin and Offset and compute the seed once? What I have here gives me the same Seed results across a very large graph, between Mac and PC computers, using all sorts of PCGEx nodes.
