### PR TITLE
Move GeometryScriptingCore to public deps for runtime

### DIFF
--- a/Source/PCGExtendedToolkit/PCGExtendedToolkit.Build.cs
+++ b/Source/PCGExtendedToolkit/PCGExtendedToolkit.Build.cs
@@ -31,6 +31,7 @@ public class PCGExtendedToolkit : ModuleRules
 				"Core",
 				"CoreUObject",
 				"Engine",
+				"GeometryScriptingCore",
 				"PCG",
 				"PCGGeometryScriptInterop"
 			}
@@ -40,7 +41,6 @@ public class PCGExtendedToolkit : ModuleRules
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"GeometryScriptingCore",
 				"RenderCore",
 				"RHI",
 				"GeometryCore",


### PR DESCRIPTION
_PR description adapted from Discord chat in Bugs channel._

Based on several days of testing across multiple projects, I am reasonably confident this patch fixes a crash on engine startup. This is NOT specific to a single commit, but for reference I am working right now against the Sept 2 release. (I've observed the crash for several months, just didn't have a probable solution until now). Since the crash was intermittent, it is hard to be 100% confident, but it has not recurred since I made this change. I am extremely confident the patch does no harm, but I have tested only on Linux.

### Symptom

Intermittent crash on starting the engine, with an error that PCGEx plugin (runtime, not editor) could not be loaded because it could not load PCGGeometryScriptInterop module as a dependency. An apparent workaround ("apparent" explained below) was to delete the Intermediate directory contents in my project then rebuild the entire project solution in my IDE. I could not understand why the crash would happen between Unreal Editor sessions even though I hadn't touched the C++ code of my project or of PCGEx.

The most recent crash was (finally) reproducible even after recompiling the project and PCGEx. Looking into the dependencies of the shared object files, and the details in the UE logs, I noticed some patterns I had not detected before:
* The crash was in loading PCGEx runtime, not editor.,
* Both PCGEx modules depend on PCGGeometryScriptInterop.,
* Both PCGEx modules have PCGGeometryScriptInterop as a public dependency in their build.cs.

Looking deeper into the dependency tree, I found that PCGExEditor publicly depends on GeometryScriptingCore, but PCGEx (runtime) depends privately* on GeometryScriptingCore.

I haven't examined every line of PCGEx code, but I reasoned that PCGExEditor will handle things like editor UI, saving assets to the game content directory tree, etc. It seemed unlikely the editor module would have code that consumes or emits types that are exported by GeometryScriptingCore, but runtime would only use those types privately.

### Hypotheses

1. PCGEx editor and runtime consume or emit GeometryScriptingCore types somewhere in their exported APIs (or perhaps editor actually doesn't, but that modified hypothesis still leads to my proposed solution).
2. As the engine starts up, enough other modules depend on GeometryScriptingCore that it is usually already loaded by the tiime PCGEx runtime is loading. PCGEx runtime needs GeometryScriptingCore but didn't ask of it as a public, but since it's already there everything still happens to work. However, this is a race condition, so if the engine tries to load PCGEx runtime as the first module that needs GeometryScriptingCore, it will fail.
3. The apparent "fix by recompiling" was a red herring; the actual impact on the situation was from my system flushing I/O buffers etc. while running the large compiles. The next startup of UE was unlikely to reproduce the rare "winner" condition required for the race condition to cause a crash.

### Patch Description

Simply move GeometryScriptingCore from a private to a public dependency in the PCGExtendedToolkit.build.cs file, per this pull request.

I am highly confident the patch will do no harm, and reasonably confident that it is necessary and sufficient to fix the crash (higher confidence of "necessary" than "sufficient").

### Supplemental

Although the patch is tiny, I am putting this detailed documentation into the PR because it may be useful for resolving this class of problem in the future.

