### PR TITLE
Fix conditional compile directive preventing Android packaging

### DIFF
--- a/Source/PCGExtendedToolkit/Private/PCGExFactoryProvider.cpp
+++ b/Source/PCGExtendedToolkit/Private/PCGExFactoryProvider.cpp
@@ -85,6 +85,11 @@ FPCGElementPtr UPCGExFactoryProviderSettings::CreateElement() const
 	return MakeShared<FPCGExFactoryProviderElement>();
 }
 
+const FPCGDataTypeBaseId& UPCGExFactoryProviderSettings::GetFactoryTypeId() const
+{
+	return FPCGExFactoryDataTypeInfo::AsId();
+}
+
 #if WITH_EDITOR
 FString UPCGExFactoryProviderSettings::GetDisplayName() const { return TEXT(""); }
 FLinearColor UPCGExFactoryProviderSettings::GetNodeTitleColor() const { return GetDefault<UPCGExGlobalSettings>()->ColorDebug; }
@@ -102,11 +107,6 @@ bool UPCGExFactoryProviderSettings::GetPinExtraIcon(const UPCGPin* InPin, FName&
 		return GetDefault<UPCGExGlobalSettings>()->GetPinExtraIcon(InPin, OutExtraIcon, OutTooltip, false);
 	}
 	return true;
-}
-
-const FPCGDataTypeBaseId& UPCGExFactoryProviderSettings::GetFactoryTypeId() const
-{
-	return FPCGExFactoryDataTypeInfo::AsId();
 }
 
 


### PR DESCRIPTION
Method UPCGExFactoryProviderSettings::GetFactoryTypeId(), which appears to be new for the 5.7-Update branch, was enclosed in WITH_EDITOR conditional compilation in the source file but not the corresponding header file. It is referenced by other runtime code, so having it editor-only is not viable.

This problem was not being detected when the plugin is built as an engine-installed plugin (I am not sure why not), but it caused packaging for Android (and quite possibly other platforms) to fail with a linker error that the symbol could not be resolved.

This fix moves the method implementation outside the WITH_EDITOR condition to make it available in editor and runtime.

As far as I can tell, this affects only the 5.7-Update branch, but since an unrelated engine bug prevents Android packaging of PCGEx on UE 5.6, I am unable to fully test that 5.6 is not affected. My assertion that this is 5.7-only is based on code inspection.