### PR TITLE
Include path error and one missing include

### DIFF
--- a/Source/PCGExtendedToolkit/Private/Data/PCGExProxyData.cpp
+++ b/Source/PCGExtendedToolkit/Private/Data/PCGExProxyData.cpp
@@ -4,7 +4,7 @@
 #include "Data/PCGExProxyData.h"
 
 #include "PCGExTypes.h"
-#include "details/PCGExMacros.h"
+#include "Details/PCGExMacros.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExDataHelpers.h"
 #include "Data/PCGExPointIO.h"

--- a/Source/PCGExtendedToolkit/Public/Paths/PCGExExtrudeTensors.h
+++ b/Source/PCGExtendedToolkit/Public/Paths/PCGExExtrudeTensors.h
@@ -10,6 +10,7 @@
 #include "PCGExPathProcessor.h"
 #include "PCGExSorting.h"
 #include "Data/PCGExDataForward.h"
+#include "Data/PCGExPointFilter.h"
 
 #include "Transform/PCGExTensorsTransform.h"
 #include "Transform/PCGExTransform.h"


### PR DESCRIPTION
The result after these two fixes compiles for Linux x64 and arm64 and for Android.