### PR TITLE
Fix unstable cases on DataAssetCollection when using External Assets

### DIFF
--- a/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
@@ -5,6 +5,7 @@
 
 #include "Engine/World.h"
 #include "Misc/PackageName.h"
+#include "Serialization/ArchiveCrc32.h"
 #include "UObject/ObjectSaveContext.h"
 #include "UObject/Package.h"
 #include "UObject/SavePackage.h"
@@ -414,6 +415,22 @@ namespace PCGExSharedCompact
 		UPackage* TargetPackage = CreatePackage(*DesiredPackagePath);
 		check(TargetPackage);
 
+		// SavePackage refuses to overwrite a package that is only partially loaded -- doing so
+		// would clobber the unloaded on-disk exports (see SavePackage2.cpp IsFullyLoaded guard).
+		// When the destination already exists on disk but was never loaded this session,
+		// CreatePackage hands back an unloaded stub (IsFullyLoaded() == false). This is the
+		// common case during cook: per-entry ExportedDataAssets are reached only via soft refs
+		// (Staging.Path), so a project-wide rebuild that force-loads collections never pulls the
+		// data-asset packages in. Fully load the target first -- it both materializes the
+		// existing occupant for the eviction below and makes the resulting package saveable.
+		// Newly-created packages with no file on disk already report IsFullyLoaded() == true, so
+		// this is a no-op for them. (Shared collections don't hit this because CompactShared
+		// LoadSynchronous()'s their external package back before modifying it.)
+		if (!TargetPackage->IsFullyLoaded())
+		{
+			TargetPackage->FullyLoad();
+		}
+
 		// If something already owns the target name in the target package, evict it. Renaming
 		// onto a name conflict would otherwise assert; we expect this on subsequent rebuilds
 		// when an old externalized asset is still loaded in the editor.
@@ -595,9 +612,49 @@ namespace PCGExSharedCompact
 			return MeshContentEquals(A, B);
 		}
 
+		// Process-stable ordering key. MUST NOT derive from GetTypeHash(FName/FSoftObjectPath):
+		// those hash the per-process FName comparison index (FNameEntryId::ToUnstableInt), which
+		// is assigned in name-registration order and therefore differs between editor sessions and
+		// the cooker. Using such a hash as a sort key reshuffles the shared collection every run,
+		// which silently re-points every baked Tag_EntryIdx (a raw Entries index) at a different
+		// mesh. Every ingredient below is either a raw scalar or a string / FArchiveCrc32 hash
+		// (FArchiveCrc32 stringifies FName & UObject paths), so the key is identical in any process.
+		//
+		// The key must also fully discriminate everything MeshContentEquals compares, so two
+		// distinct entries can never collide to the same key (which would re-introduce an unstable
+		// tie-break): mesh path, material-variant mode, slot, descriptor source, property-component
+		// hash, both component descriptors (CRC), and the material-override variant lists.
 		static FString SortKey(const FPCGExMeshCollectionEntry& E)
 		{
-			return E.StaticMesh.ToSoftObjectPath().ToString();
+			FArchiveCrc32 DescriptorCrc;
+			FSoftISMComponentDescriptor::StaticStruct()->SerializeBin(
+				DescriptorCrc, const_cast<FSoftISMComponentDescriptor*>(&E.ISMDescriptor));
+			FPCGExStaticMeshComponentDescriptor::StaticStruct()->SerializeBin(
+				DescriptorCrc, const_cast<FPCGExStaticMeshComponentDescriptor*>(&E.SMDescriptor));
+
+			FString Key = E.StaticMesh.ToSoftObjectPath().ToString();
+			Key += FString::Printf(TEXT("|MV=%d|SI=%d|DS=%d|PCH=%u|DESC=%08X"),
+				static_cast<int32>(E.MaterialVariants),
+				E.SlotIndex,
+				static_cast<int32>(E.DescriptorSource),
+				E.PropertyComponentHash,
+				DescriptorCrc.GetCrc());
+
+			for (const FPCGExMaterialOverrideSingleEntry& S : E.MaterialOverrideVariants)
+			{
+				Key += FString::Printf(TEXT("|MOV=%d:%s"),
+					S.Weight, *S.Material.ToSoftObjectPath().ToString());
+			}
+			for (const FPCGExMaterialOverrideCollection& V : E.MaterialOverrideVariantsList)
+			{
+				Key += FString::Printf(TEXT("|MOL=%d"), V.Weight);
+				for (const FPCGExMaterialOverrideEntry& O : V.Overrides)
+				{
+					Key += FString::Printf(TEXT(",%d:%s"),
+						O.SlotIndex, *O.Material.ToSoftObjectPath().ToString());
+				}
+			}
+			return Key;
 		}
 
 		static const TArray<FPCGExMeshCollectionEntry>& Contributions(const FPCGExPCGDataAssetCollectionEntry& E)
@@ -679,7 +736,8 @@ namespace PCGExSharedCompact
 	// (identity via TPolicy::Hash + TPolicy::Equals), then rewrite Tag_EntryIdx on the
 	// policy's pin against the resulting shared indices. Tags/Category/PropertyOverrides
 	// on existing shared entries are preserved across rebuilds when identity survives.
-	// Deterministic ordering: (hash, sort-key) ascending -- stable across cold cooks.
+	// Deterministic ordering: by content-derived SortKey ascending -- stable across cold cooks
+	// and editor restarts (does NOT depend on the per-process FName comparison-index hash).
 	template <typename TPolicy>
 	static void CompactShared(
 		UObject* Outer,
@@ -795,12 +853,14 @@ namespace PCGExSharedCompact
 				AllGroups.Add(MoveTemp(G));
 			}
 		}
+		// Order purely by the content-derived, process-stable SortKey. FGroup::Hash is NOT used
+		// here: it comes from TPolicy::Hash -> GetTypeHash(FSoftObjectPath) -> GetTypeHash(FName),
+		// which is the per-process FName comparison index and reshuffles across sessions/cooks.
+		// TPolicy::SortKey fully discriminates every distinct group (see FMeshPolicy::SortKey), so
+		// no two groups share a key and there is no tie-break to fall back on. Hash is retained
+		// only as an in-process bucket key for grouping/preservation above.
 		AllGroups.Sort([](const FGroup& A, const FGroup& B)
 		{
-			if (A.Hash != B.Hash)
-			{
-				return A.Hash < B.Hash;
-			}
 			return A.SortKey < B.SortKey;
 		});
 
@@ -1216,13 +1276,23 @@ void UPCGExPCGDataAssetCollection::PreSave(FObjectPreSaveContext ObjectSaveConte
 {
 	// Cook-time safety net for users who edited a source level and cooked without a manual
 	// rebuild (or recovered from a mid-edit editor crash). Idempotent.
+	//
+	// Only re-bake the IN-MEMORY state here. 
+	// We deliberately do NOT call SaveExternalPackages() during cook:
+	//  - SavePackage(Pkg, nullptr, ...) is an editor (uncooked) save that writes the SOURCE
+	//    .uasset under /Content/. A cook must be read-only w.r.t. source content; writing it
+	//    dirties the workspace and fails / forces a writable-flip on read-only (Perforce) files.
+	//  - It mutates packages the cooker may have already cooked (no effect) or not yet cooked
+	//    (changing the source mid-cook), making the output depend on cook scheduling.
+	//  - In concurrent / cook-by-the-book saving, GIsSavingPackage is held for the whole batch;
+	//    a nested non-concurrent SavePackage clears it on scope-exit, breaking that invariant.
+	// On most cases (except for potential multi-threaded cooks), external objects are
+	// cooked from the loaded in-memory ones which should be enough.
+	// Actually might want to consider just removing this as the levels aren't actually being re-harvested
+	// at all here so the safety net is not quite comprehensive in the first place.
 	if (ObjectSaveContext.IsCooking())
 	{
 		RebuildSharedCollections();
-		if (IsExternalActive())
-		{
-			SaveExternalPackages();
-		}
 	}
 	Super::PreSave(ObjectSaveContext);
 }

--- a/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Core/PCGExAssetCollection.cpp
@@ -1004,7 +1004,14 @@ void UPCGExAssetCollection::PostLoad()
 	// a PCG graph that triggered THIS soft-load sees pre-rebuild state for its current
 	// run; subsequent runs see fresh data. Complements OnAssetUpdatedOnDisk which only
 	// fires for collections already loaded when a referenced asset is saved.
-	if (!GEditor || !GEditor->IsTimerManagerValid() || !bAutoRebuildStaging)
+	//
+	// Never during a cook: auto-rebuild is an interactive editor convenience. A cook shouldn't
+	// dirty source except for upgrade or fixup, moreover the deferred rebuild would re-harvest
+	// source levels from an uninitialized world (transforms will read back as Identity)
+	// corrupting the result for PCGDataAssetCollection from commandlet.
+	// Cooked output uses the committed, editor-rebuilt content; staleness should be an
+	// authoring concern, not a cook concern.
+	if (!GEditor || !GEditor->IsTimerManagerValid() || !bAutoRebuildStaging || IsRunningCookCommandlet())
 	{
 		return;
 	}


### PR DESCRIPTION
# Fix rebuild and save issues on PCGExPCGDataAssetCollection when using Level entry with External Assets

## Summary

Entries in shared collections produced by `UPCGExPCGDataAssetCollection` (`SharedMeshCollection` / `SharedLevelCollection`) are ordered non-deterministically:
the order is stable within a single editor session but changes on editor restart and in the cooker. Because the baked `Tag_EntryIdx` attribute on generated `UPCGDataAsset` points encodes a **raw `Entries` array index**, any re-order in a different process silently re-points every point at a different entry — e.g. a cooked build resolves the inner points of a PCG data asset to different static meshes than the editor.

This PR makes the ordering a pure function of entry content so it is byte-identical in every process (editor sessions, cooker, packaged game). It also fixes two save hazards in the same `UPCGExPCGDataAssetCollection` path: an unsafe source-package save performed during cook, and a fatal "partially loaded" failure when re-externalizing per-entry data assets whose packages were never loaded this session.

## Root cause

`PCGExSharedCompact::CompactShared` sorted the merged entries by `(FGroup::Hash, SortKey)` with `Hash` as the **primary** key:

```cpp
AllGroups.Sort([](const FGroup& A, const FGroup& B)
{
    if (A.Hash != B.Hash) { return A.Hash < B.Hash; }
    return A.SortKey < B.SortKey;
});
```

`FGroup::Hash` comes from `MeshContentHash` / `FLevelPolicy::Hash`, which is built from `GetTypeHash(FSoftObjectPath)`:

```
GetTypeHash(FSoftObjectPath)
  -> GetTypeHash(FTopLevelAssetPath)
  -> GetTypeHash(FName)
  -> FNameEntryId::ToUnstableInt()   // per-process FName comparison index
```

The FName comparison index is assigned in name-registration order, which differs between processes. So the primary sort key — and therefore the resulting entry order — changes every time the name table is built differently (every editor restart, every cook).

Note: the baked IDs resolution (`FPickUnpacker::ResolveEntry` → `GetEntryRaw(EntryIndex)`) is a GUID lookup plus a raw array index. And the raw `EntryIndex` is only meaningful against an order that is reproduced identically — which the unstable sort broke.

## Changes

**File:** `Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp`

### 1. Deterministic, content-derived ordering in `CompactShared`

- `FMeshPolicy::SortKey` now returns a fully-discriminating, process-stable string that mirrors every field `MeshContentEquals` compares: mesh path, `MaterialVariants`, `SlotIndex`, `DescriptorSource`, `PropertyComponentHash`, an `FArchiveCrc32` of both component descriptors, and the material-override variant lists. `FArchiveCrc32` stringifies `FName`/`UObject` paths, so its CRC is identical across processes (unlike `GetTypeHash`).
- The `AllGroups.Sort` comparator now orders by `SortKey` only. Because `SortKey` fully discriminates every distinct group, there is no tie to fall back on, and the unstable `Hash` is no longer used for ordering (it is retained solely as an in-process bucket key for grouping / field preservation).
- `FLevelPolicy::SortKey` (the level world path) was already fully discriminating and stable, so the comparator change covers the level pin as well.
- Added `#include "Serialization/ArchiveCrc32.h"`.

### 2. Do not save source packages during cook in `PreSave`

The cook branch of `UPCGExPCGDataAssetCollection::PreSave` called `SaveExternalPackages()`, which issues `UPackage::SavePackage(Pkg, nullptr, ...)` (an editor/uncooked save) against the external `SharedMeshCollection` / `ExportedDataAsset` source packages. During a cook this is unsafe:

- It writes the **source** `.uasset` under `/Content/` — a cook must be read-only with respect to source content; this dirties the workspace and fails / forces a writable-flip on read-only (e.g. Perforce) files.
- It mutates packages the cooker may have already cooked (no effect) or not yet cooked (changing the source mid-cook), making output dependent on cook scheduling.
- In concurrent / cook-by-the-book saving, `GIsSavingPackage` is held for the whole batch; a nested non-concurrent `SavePackage` clears it on scope-exit, breaking that invariant.

The cook branch now only calls `RebuildSharedCollections()` to re-bake the in-memory state; the cooker serializes each external package's current in-memory state into the cooked output on its own. `SaveExternalPackages()` is left in place (still usable from editor flows) but is no longer invoked during cook.

### 3. Fully load the destination package before re-externalizing in `ExternalizeUObject`

`PCGExSharedCompact::ExternalizeUObject` did `CreatePackage(path)` and renamed a freshly-built object into it. When the destination already exists on disk but was never loaded this session, `CreatePackage` returns an unloaded stub (`IsFullyLoaded() == false`), and `SavePackage` then refuses to write it ("Asset '...' cannot be saved as it has only been partially loaded"), because overwriting would clobber the package's unloaded on-disk exports.

This reliably fires when re-externalizing per-entry `ExportedDataAsset`s during a project-wide rebuild at cook time: those packages are reached only via soft refs (`Staging.Path`), so a rebuild that force-loads the *collections* never pulls the *data-asset* packages into memory.
(The shared `SharedMeshCollection` / `SharedLevelCollection` packages don't hit this because `CompactShared` already `LoadSynchronous()`s them back before modifying them; only the per-entry data assets lacked an equivalent load-back.)
Fix: after `CreatePackage`, fully load the target if needed, before the eviction + rename:

```cpp
if (!TargetPackage->IsFullyLoaded())
{
    TargetPackage->FullyLoad();
}
```

`FullyLoad()` `LoadPackage()`s an existing-on-disk stub (materializing the old occupant so the existing eviction step can rename it aside) and is a no-op for brand-new packages, which already report `IsFullyLoaded() == true`. The freshly-built object is a separate, never-serialized UObject, so loading does not overwrite it: the sequence is load-old → evict-old-to-transient → rename-new-in. The `FullyLoad` must precede the rename so the loader doesn't deserialize the old export onto a name the new object already occupies.

### 4. Skip the `PostLoad` auto-rebuild during cook

`UPCGExAssetCollection::PostLoad` schedules a next-tick `EDITOR_RebuildStaleEntries()` when `bAutoRebuildStaging` is true — an interactive convenience that refreshes entries whose source asset changed on disk. During a cook this is undesirable: mainly for `Level`-source entries, it re-harvests the source level from a freshly-loaded, uninitialized world, so every exported point transform reads back as `Identity` (`ComponentToWorld` is transient and only computed on component registration / world init).

Fix: also bail when `IsRunningCookCommandlet()`, so scheduling is a no-op during cook regardless of whether the cook loop ticks the editor timer manager:

```cpp
if (!GEditor || !GEditor->IsTimerManagerValid() || !bAutoRebuildStaging || IsRunningCookCommandlet())
{
    return;
}
```


## Steps to reproduce (before this PR)

1. Create a `UPCGExPCGDataAssetCollection` in external mode (`bUseExternalAssets = true`, `ExportFolder` set) with a Level-source entry whose level contains **two or more distinct static meshes**.
2. Rebuild staging. Note the order of entries in the generated external `UPCGExMeshCollection` (and the `Tag_EntryIdx` values baked onto the data asset's `Meshes`-pin points).
3. Restart the editor **without saving any new changes**.
4. Rebuild staging again.

**Observed:** the external mesh collection's entries are emitted in a *different order* than in step 2, even though no content changed. Consequently the previously-baked `Tag_EntryIdx` indices now reference different entries — i.e. points resolve to the wrong meshes. The same re-order happens in the cooker process, which is why a cooked build can resolve the inner points of a PCG data asset to different meshes than the editor.

**Expected (after this PR):** the entry order is identical across editor restarts and in the cooker, so baked indices always resolve to the same entries.

### Rebuild partial-load save error (change 3)

1. With the same external-mode collection, ensure its generated `*_Data` assets exist on disk (built and saved at least once) but are **not** loaded into memory.(restart the editor and DON'T touch that data asset)
2. Trigger a project-wide `EDITOR_RebuildStagingData()` + `SavePackage` of the regenerated per-entry data assets in a context that loaded only the collections (e.g. a cook-time rebuild that reaches data assets solely via soft `Staging.Path`).

**Observed:** `SavePackage` fails with "Asset '..._Data' cannot be saved as it has only been partially loaded" (fatal in a commandlet), because the destination package is an unloaded stub.

**Expected (after this PR):** the destination package is fully loaded before re-externalizing, so the regenerated data asset saves successfully.
