### PR TITLE
Fix: Cancelling during `Boot` permanently stuck the task paused in `PrepareData` if has asset dependencies

### DIFF
--- a/Source/PCGExCore/Private/Core/PCGExContext.cpp
+++ b/Source/PCGExCore/Private/Core/PCGExContext.cpp
@@ -346,6 +346,11 @@ void FPCGExContext::OnAsyncWorkEnd(const bool bWasCancelled)
 
 	if (bWasCancelled || IsWorkCancelled())
 	{
+		// A cancel can land while async work is still in flight and the context is paused. CancelExecution
+		// unpauses once, but a subsequent re-pause can consume that wake-up and strand the task in PCG's
+		// PausedTasks forever. Unpause again here so PCG re-ticks and finalizes the cancelled task cleanly
+		// (CanExecute() is false, so the re-tick just completes it - no double work).
+		UnpauseContext();
 		return;
 	}
 

--- a/Source/PCGExCore/Private/Core/PCGExElement.cpp
+++ b/Source/PCGExCore/Private/Core/PCGExElement.cpp
@@ -80,6 +80,18 @@ bool IPCGExElement::AdvancePreparation(FPCGExContext* Context, const UPCGExSetti
 			}
 		}
 
+		// Many nodes cancel from their Boot() override by writing:
+		// {
+		//     return Context->CancelExecution(TEXT("..."));
+		// }
+		// and FPCGExContext::CancelExecution() returns true. 
+		// so Boot() returns true even though it just cancelled the context. 
+		// The `if (!Boot())` above does not catch that, so re-check here: 
+		// if Boot cancelled (or completed) execution, finalize now. Otherwise
+		// we would fall through to RegisterAssetDependencies/LoadAssets and re-pause an already-cancelled context,
+		// whose async completion (OnAsyncWorkEnd) refuses to resume it -> permanently wedged in PrepareData.
+		PCGEX_EXECUTION_CHECK_C(Context)
+
 		for (UPCGExInstancedFactory* Op : Context->InternalOperations)
 		{
 			Op->RegisterAssetDependencies(Context);


### PR DESCRIPTION
(Note: below summary is written by AI, while tests are conducted in a Unreal 5.7 project that was bitten by this bug)

## Summary

A PCGEx node that cancels its own execution from `Boot()` **and** has asset
dependencies to load can become permanently stuck — its task stays paused in the
`PrepareData` phase forever and never completes (so the host graph that owns it never
finishes either).

The fix is two small changes in `PCGExCore`:

| File | Function | Change |
|------|----------|--------|
| `Source/PCGExCore/Private/Core/PCGExElement.cpp` | `IPCGExElement::AdvancePreparation` | Re-check execution state right after `Boot()`. |
| `Source/PCGExCore/Private/Core/PCGExContext.cpp` | `FPCGExContext::OnAsyncWorkEnd` | Unpause the context before the cancel early-return. |

---

## Root cause

`FPCGExContext::CancelExecution()` returns `true`. Many nodes cancel from their `Boot`
override by writing:

```cpp
return Context->CancelExecution(TEXT("..."));
```

so `Boot()` returns **`true`** even though it just cancelled the context.
(`PCGExStagingDistribute` is one such node: in the per-point "Attribute" collection
source it does `return Context->CancelExecution(TEXT("Failed to load any collections."))`
when none of the discovered collection paths resolve.)

In `IPCGExElement::AdvancePreparation`, the preparation state machine guards Boot like this:

```cpp
if (Context->IsState(PCGExCommon::States::State_Preparation))
{
    if (!Boot(Context))
    {
        return Context->CancelExecution(FString());
    }

    // ... falls through to here even if Boot() cancelled the context ...
    for (UPCGExInstancedFactory* Op : Context->InternalOperations)
    {
        Op->RegisterAssetDependencies(Context);
    }

    Context->RegisterAssetDependencies();
    if (Context->HasAssetRequirements() && Context->LoadAssets())
    {
        return false; // pause for async asset loading
    }

    PostLoadAssetsDependencies(Context);
}
```

Because `Boot()` returned `true`, the `if (!Boot(Context))` branch is skipped and the
function falls through to `RegisterAssetDependencies()` / `LoadAssets()` — **on a context
that is already cancelled**.

For a node that has registered asset dependencies, `LoadAssets()` returns `true` and
`AdvancePreparation` returns `false` to pause for the async load. The context is now paused
again. When that async load completes, `FPCGExContext::OnAsyncWorkEnd` does:

```cpp
if (bWasCancelled || IsWorkCancelled())
{
    return; // assumes the cancel path already finalized the context
}
```

It early-returns because the context is cancelled, and never drives the context forward.
The single `UnpauseContext()` that `CancelExecution` performed has been consumed by the
re-pause, so nothing ever resumes the task: it sits in the host's paused-task list
indefinitely, in `phase=PrepareData`.

Nodes **without** asset requirements are unaffected: `LoadAssets()` returns `false`, the
function continues to `ReadyForExecution()`, and the cancellation is honored normally once
execution begins. The bug only bites the combination of *cancel-in-`Boot`* **and**
*has asset dependencies*.

---

## Fix 1 — honor a Boot-time cancel before loading assets

`Source/PCGExCore/Private/Core/PCGExElement.cpp`, `IPCGExElement::AdvancePreparation`,
immediately after the `Boot()` block:

```cpp
        {
            TRACE_CPUPROFILER_EVENT_SCOPE(IPCGExElement::InitializeData::Boot)
            if (!Boot(Context))
            {
                return Context->CancelExecution(FString());
            }
        }

        // Boot can cancel the context while still returning true, because CancelExecution() returns true
        // (e.g. PCGExStagingDistribute: "Failed to load any collections."). The `if (!Boot())` above does
        // not catch that, so re-check here: if Boot cancelled (or completed) execution, finalize now. Otherwise
        // we would fall through to RegisterAssetDependencies/LoadAssets and re-pause an already-cancelled context,
        // whose async completion (OnAsyncWorkEnd) refuses to resume it -> permanently wedged in PrepareData.
        PCGEX_EXECUTION_CHECK_C(Context)
```

`PCGEX_EXECUTION_CHECK_C(_CONTEXT)` expands to
`if (!_CONTEXT->CanExecute()) { return true; }`, and `CanExecute()` is `false` once the
context is cancelled or completed. So a Boot-time cancel now finalizes preparation
immediately (returns "done") instead of entering asset loading. The normal path
(`Boot` succeeds and does not cancel) is unaffected — `CanExecute()` is `true`, the macro
is a no-op.

This is the actual root-cause fix.

---

## Fix 2 — defensive: unpause on cancel in `OnAsyncWorkEnd`

`Source/PCGExCore/Private/Core/PCGExContext.cpp`, `FPCGExContext::OnAsyncWorkEnd`:

```cpp
    if (bWasCancelled || IsWorkCancelled())
    {
        // A cancel can land while async work is still in flight and the context is paused. CancelExecution
        // unpauses once, but a subsequent re-pause can consume that wake-up and strand the task in PCG's
        // PausedTasks forever. Unpause again here so PCG re-ticks and finalizes the cancelled task cleanly
        // (CanExecute() is false, so the re-tick just completes it - no double work).
        UnpauseContext();
        return;
    }
```

This is a belt-and-suspenders guard for the same failure mode (a cancellation that lands
while the context is paused on async work) reached via any other path. Because the context
is cancelled, `CanExecute()` is `false`, so the resulting re-tick simply finalizes the task —
there is no risk of double execution.

With Fix 1 in place, the reproducing case never reaches `LoadAssets()`, so this guard is not
strictly required for that specific repro; it is included to make the cancel-while-paused
contract robust generally. It can be dropped if a strictly minimal change is preferred.