### PR TITLE
Fix deadlock when cancelling PCG generation that runs FPickUnpacker collection loads

### DIFF
--- a/Source/PCGExCollections/Private/Elements/PCGExStagingLoadPCGData.cpp
+++ b/Source/PCGExCollections/Private/Elements/PCGExStagingLoadPCGData.cpp
@@ -447,9 +447,11 @@ bool FPCGExPCGDataAssetLoaderElement::Boot(FPCGExContext* InContext) const
 
 	// Setup collection unpacker
 	Context->CollectionUnpacker = MakeShared<PCGExCollections::FPickUnpacker>();
-	Context->CollectionUnpacker->UnpackPin(InContext);
+	// Deferred (cancel-safe) unpack: registers the referenced collections as async asset dependencies
+	// instead of blocking-loading them here on the worker. Resolved in the initial execution below.
+	Context->CollectionUnpacker->UnpackPinDeferred(InContext);
 
-	if (!Context->CollectionUnpacker->HasValidMapping())
+	if (!Context->CollectionUnpacker->HasCollectedPicks())
 	{
 		PCGE_LOG(Error, GraphAndLog, FTEXT("Could not rebuild a valid asset mapping from the provided map."));
 		return false;
@@ -480,6 +482,12 @@ bool FPCGExPCGDataAssetLoaderElement::AdvanceWork(FPCGExContext* InContext, cons
 
 	PCGEX_ON_INITIAL_EXECUTION
 	{
+		// Collections were registered as async dependencies in Boot and are now loaded; build the map.
+		if (!Context->CollectionUnpacker->ResolveDeferred(Context))
+		{
+			return Context->CancelExecution(TEXT("Could not rebuild a valid asset mapping from the provided map."));
+		}
+
 		if (!Context->StartBatchProcessingPoints(
 			[&](const TSharedPtr<PCGExData::FPointIO>& Entry)
 			{

--- a/Source/PCGExCollections/Private/Elements/PCGExStagingLoadProperties.cpp
+++ b/Source/PCGExCollections/Private/Elements/PCGExStagingLoadProperties.cpp
@@ -39,9 +39,12 @@ bool FPCGExStagingLoadPropertiesElement::Boot(FPCGExContext* InContext) const
 	PCGEX_CONTEXT_AND_SETTINGS(StagingLoadProperties)
 
 	Context->CollectionPickUnpacker = MakeShared<PCGExCollections::FPickUnpacker>();
-	Context->CollectionPickUnpacker->UnpackPin(InContext, PCGExCollections::Labels::SourceCollectionMapLabel);
+	// Deferred (cancel-safe) unpack: registers the referenced collections as async asset dependencies
+	// instead of blocking-loading them here on the worker. The collection map is built in
+	// ResolveDeferred() once the context's asset phase has loaded them (see initial execution below).
+	Context->CollectionPickUnpacker->UnpackPinDeferred(InContext, PCGExCollections::Labels::SourceCollectionMapLabel);
 
-	if (!Context->CollectionPickUnpacker->HasValidMapping())
+	if (!Context->CollectionPickUnpacker->HasCollectedPicks())
 	{
 		PCGE_LOG(Error, GraphAndLog, FTEXT("Could not rebuild a valid asset mapping from the provided map."));
 		return false;
@@ -94,6 +97,12 @@ bool FPCGExStagingLoadPropertiesElement::AdvanceWork(FPCGExContext* InContext, c
 	PCGEX_EXECUTION_CHECK
 	PCGEX_ON_INITIAL_EXECUTION
 	{
+		// Collections were registered as async dependencies in Boot and are now loaded; build the map.
+		if (!Context->CollectionPickUnpacker->ResolveDeferred(Context))
+		{
+			return Context->CancelExecution(TEXT("Could not rebuild a valid asset mapping from the provided map."));
+		}
+
 		if (!Context->StartBatchProcessingPoints(
 			[&](const TSharedPtr<PCGExData::FPointIO>& Entry)
 			{

--- a/Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp
+++ b/Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp
@@ -365,8 +365,11 @@ namespace PCGExCollections
 		PCGExHelpers::SafeReleaseHandle(CollectionsHandle);
 	}
 
-	bool FPickUnpacker::UnpackDataset(FPCGContext* InContext, const UPCGParamData* InAttributeSet)
+	bool FPickUnpacker::CollectDataset(FPCGContext* InContext, const UPCGParamData* InAttributeSet)
 	{
+		// Validate the attribute set and accumulate its (CollectionIdx -> path) picks into
+		// CollectedCollectionPaths. This does NOT load anything -- both the blocking and the deferred
+		// paths share this, then differ only in how/when the collections are brought into memory.
 		const UPCGMetadata* Metadata = InAttributeSet->Metadata;
 		TUniquePtr<FPCGAttributeAccessorKeysEntries> Keys = MakeUnique<FPCGAttributeAccessorKeysEntries>(Metadata);
 
@@ -377,8 +380,6 @@ namespace PCGExCollections
 			return false;
 		}
 
-		CollectionMap.Reserve(CollectionMap.Num() + NumEntries);
-
 		const FPCGMetadataAttribute<int32>* CollectionIdx = InAttributeSet->Metadata->GetConstTypedAttribute<int32>(Labels::Tag_CollectionIdx);
 		const FPCGMetadataAttribute<FSoftObjectPath>* CollectionPath = InAttributeSet->Metadata->GetConstTypedAttribute<FSoftObjectPath>(Labels::Tag_CollectionPath);
 
@@ -388,56 +389,91 @@ namespace PCGExCollections
 			return false;
 		}
 
-		{
-			TSharedPtr<TSet<FSoftObjectPath>> CollectionPaths = MakeShared<TSet<FSoftObjectPath>>();
-
-			for (int32 i = 0; i < NumEntries; i++)
-			{
-				CollectionPaths->Add(CollectionPath->GetValueFromItemKey(i));
-			}
+		CollectedCollectionPaths.Reserve(CollectedCollectionPaths.Num() + NumEntries);
 
 #if WITH_EDITOR
-			FPCGDynamicTrackingHelper DynamicTracking;
-			DynamicTracking.EnableAndInitialize(InContext, CollectionPaths->Num());
-			for (const FSoftObjectPath& Path : *CollectionPaths.Get())
-			{
-				DynamicTracking.AddToTracking(FPCGSelectionKey::CreateFromPath(Path), /*bIsCulled=*/ false);
-			}
-			DynamicTracking.Finalize(InContext);
+		FPCGDynamicTrackingHelper DynamicTracking;
+		DynamicTracking.EnableAndInitialize(InContext, NumEntries);
 #endif
-
-			CollectionsHandle = PCGExHelpers::LoadBlocking_AnyThread(CollectionPaths);
-		}
 
 		for (int32 i = 0; i < NumEntries; i++)
 		{
-			int32 Idx = CollectionIdx->GetValueFromItemKey(i);
+			const int32 Idx = CollectionIdx->GetValueFromItemKey(i);
+			const FSoftObjectPath Path = CollectionPath->GetValueFromItemKey(i);
 
-			TSoftObjectPtr<UPCGExAssetCollection> CollectionSoftPtr(CollectionPath->GetValueFromItemKey(i));
-			UPCGExAssetCollection* Collection = CollectionSoftPtr.Get();
+			if (const FSoftObjectPath* Existing = CollectedCollectionPaths.Find(Idx))
+			{
+				// Same identifier resolving to two different collections -- the map is inconsistent.
+				// (A repeat of the same (Idx, Path) is expected across rows and is fine.)
+				if (*Existing != Path)
+				{
+					PCGE_LOG_C(Error, GraphAndLog, InContext, FTEXT("Collection Idx collision."));
+					return false;
+				}
+				continue;
+			}
 
+			CollectedCollectionPaths.Add(Idx, Path);
+
+#if WITH_EDITOR
+			DynamicTracking.AddToTracking(FPCGSelectionKey::CreateFromPath(Path), /*bIsCulled=*/ false);
+#endif
+		}
+
+#if WITH_EDITOR
+		DynamicTracking.Finalize(InContext);
+#endif
+
+		return true;
+	}
+
+	bool FPickUnpacker::BuildResolvedMap(FPCGContext* InContext)
+	{
+		// Turn the collected picks into the live CollectionMap. Collections must already be in memory
+		// (blocking-loaded by UnpackDataset, or streamed in by the element's async dependency phase
+		// before ResolveDeferred is called). Idempotent: skips identifiers already resolved.
+		CollectionMap.Reserve(CollectionMap.Num() + CollectedCollectionPaths.Num());
+
+		for (const TPair<int32, FSoftObjectPath>& Pair : CollectedCollectionPaths)
+		{
+			if (CollectionMap.Contains(Pair.Key))
+			{
+				continue;
+			}
+
+			UPCGExAssetCollection* Collection = TSoftObjectPtr<UPCGExAssetCollection>(Pair.Value).Get();
 			if (!Collection)
 			{
 				PCGE_LOG_C(Error, GraphAndLog, InContext, FTEXT("Some collections could not be loaded."));
 				return false;
 			}
 
-			if (CollectionMap.Contains(Idx))
-			{
-				if (CollectionMap[Idx] == Collection)
-				{
-					continue;
-				}
-
-				PCGE_LOG_C(Error, GraphAndLog, InContext, FTEXT("Collection Idx collision."));
-				return false;
-			}
-
-			CollectionMap.Add(Idx, Collection);
+			CollectionMap.Add(Pair.Key, Collection);
 			NumUniqueEntries += Collection->GetValidEntryNum();
 		}
 
-		return true;
+		return HasValidMapping();
+	}
+
+	bool FPickUnpacker::UnpackDataset(FPCGContext* InContext, const UPCGParamData* InAttributeSet)
+	{
+		// Blocking path: collect, synchronously load, then resolve. See UnpackDataset's header warning --
+		// only use this on the game thread or in non-cancellable contexts.
+		if (!CollectDataset(InContext, InAttributeSet))
+		{
+			return false;
+		}
+
+		TSharedPtr<TSet<FSoftObjectPath>> CollectionPaths = MakeShared<TSet<FSoftObjectPath>>();
+		CollectionPaths->Reserve(CollectedCollectionPaths.Num());
+		for (const TPair<int32, FSoftObjectPath>& Pair : CollectedCollectionPaths)
+		{
+			CollectionPaths->Add(Pair.Value);
+		}
+
+		CollectionsHandle = PCGExHelpers::LoadBlocking_AnyThread(CollectionPaths);
+
+		return BuildResolvedMap(InContext);
 	}
 
 	void FPickUnpacker::UnpackPin(FPCGContext* InContext, const FName InPinLabel)
@@ -459,6 +495,43 @@ namespace PCGExCollections
 
 			UnpackDataset(InContext, ParamData);
 		}
+	}
+
+	void FPickUnpacker::UnpackPinDeferred(FPCGExContext* InContext, const FName InPinLabel)
+	{
+		// Phase 1: collect picks (no loading) and register the referenced collections as async asset
+		// dependencies on the context. The element's asset-loading phase streams them in while the
+		// context is paused, so this never blocks a worker and cannot deadlock a mid-flight Cancel().
+		for (TArray<FPCGTaggedData> Params = InContext->InputData.GetParamsByPin(InPinLabel.IsNone() ? Labels::SourceCollectionMapLabel : InPinLabel);
+		     const FPCGTaggedData& InTaggedData : Params)
+		{
+			const UPCGParamData* ParamData = Cast<UPCGParamData>(InTaggedData.Data);
+
+			if (!ParamData)
+			{
+				continue;
+			}
+
+			if (!ParamData->Metadata->HasAttribute(Labels::Tag_CollectionIdx) || !ParamData->Metadata->HasAttribute(Labels::Tag_CollectionPath))
+			{
+				continue;
+			}
+
+			CollectDataset(InContext, ParamData);
+		}
+
+		for (const TPair<int32, FSoftObjectPath>& Pair : CollectedCollectionPaths)
+		{
+			InContext->AddAssetDependency(Pair.Value);
+		}
+	}
+
+	bool FPickUnpacker::ResolveDeferred(FPCGExContext* InContext)
+	{
+		// Phase 2: the collections registered in UnpackPinDeferred have now been loaded by the
+		// context's async asset phase (the handle is kept alive by the context, so no CollectionsHandle
+		// is needed here). Build the live map.
+		return BuildResolvedMap(InContext);
 	}
 
 	// Groups points by their entry hash into FPCGMeshInstanceList partitions.

--- a/Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h
+++ b/Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h
@@ -22,6 +22,7 @@ namespace PCGExDetails
 }
 
 struct FPCGContext;
+struct FPCGExContext;
 struct FPCGMeshInstanceList;
 struct FPCGSkinnedMeshInstanceList;
 class UPCGBasePointData;
@@ -323,6 +324,18 @@ namespace PCGExCollections
 		int32 NumUniqueEntries = 0;
 		const UPCGBasePointData* PointData = nullptr;
 
+		// Picks collected from the Collection Map attribute set(s), keyed by CollectionIdx -> collection
+		// asset path. Populated by CollectDataset (no loading), then turned into CollectionMap by
+		// BuildResolvedMap once the referenced collections are in memory. Drives both the blocking
+		// (UnpackPin) and the cancel-safe deferred (UnpackPinDeferred + ResolveDeferred) paths.
+		TMap<int32, FSoftObjectPath> CollectedCollectionPaths;
+
+		/** Validate the attribute set and accumulate its (CollectionIdx -> path) picks into CollectedCollectionPaths. No loading. */
+		bool CollectDataset(FPCGContext* InContext, const UPCGParamData* InAttributeSet);
+
+		/** Build CollectionMap from CollectedCollectionPaths. Collections must already be loaded. Idempotent. */
+		bool BuildResolvedMap(FPCGContext* InContext);
+
 	public:
 		TMap<int64, TSharedPtr<TArray<int32>>> HashedPartitions;
 		TMap<int64, int32> IndexedPartitions;
@@ -335,17 +348,61 @@ namespace PCGExCollections
 			return !CollectionMap.IsEmpty();
 		}
 
+		/**
+		 * True once picks have been collected (a valid Collection Map input was found), even if the
+		 * referenced collections have not been resolved yet. Use this as the Boot-time validity check
+		 * on the deferred path, where HasValidMapping() is only true after ResolveDeferred().
+		 */
+		bool HasCollectedPicks() const
+		{
+			return !CollectedCollectionPaths.IsEmpty();
+		}
+
 		/** Get read-only access to the collection map */
 		const TMap<uint32, UPCGExAssetCollection*>& GetCollections() const
 		{
 			return CollectionMap;
 		}
 
-		/** Unpack collection mappings from an attribute set */
+		/**
+		 * Unpack collection mappings from an attribute set.
+		 * WARNING: blocking load. Safe only on the game thread or in non-cancellable contexts.
+		 * In a cancellable element prepare/execute path, use UnpackPinDeferred + ResolveDeferred instead
+		 * (see UnpackPin / LoadBlocking_AnyThread for why a blocking load deadlocks against a mid-flight cancel).
+		 */
 		bool UnpackDataset(FPCGContext* InContext, const UPCGParamData* InAttributeSet);
 
-		/** Unpack from a specific input pin */
+		/**
+		 * Unpack from a specific input pin.
+		 * WARNING: blocking load (calls LoadBlocking_AnyThread). Safe only on the game thread or in
+		 * non-cancellable contexts (e.g. mesh selectors). Inside a PCGEx element's Boot()/Execute(),
+		 * which run on a worker that PCG's Cancel() waits on, this can deadlock -- use the deferred
+		 * pair below instead.
+		 */
 		void UnpackPin(FPCGContext* InContext, FName InPinLabel = NAME_None);
+
+		/**
+		 * Cancel-safe, two-phase replacement for UnpackPin(), for use from a PCGEx element's Boot().
+		 *
+		 * Phase 1 (this call): reads the Collection Map input pin and registers every referenced
+		 * collection as an async asset dependency on the context (FPCGExContext::AddAssetDependency)
+		 * WITHOUT blocking. The element's normal asset-loading phase then streams them in via the
+		 * task system, with the context paused -- so a concurrent Cancel() resolves through PCG's
+		 * no-wait paused-task path instead of blocking the game thread on a worker.
+		 *
+		 * Check HasCollectedPicks() after this to validate a map input was found.
+		 *
+		 * Phase 2: call ResolveDeferred() once the assets are loaded (e.g. at the start of the
+		 * initial execution, or in PostLoadAssetsDependencies) to build the collection map.
+		 */
+		void UnpackPinDeferred(FPCGExContext* InContext, FName InPinLabel = NAME_None);
+
+		/**
+		 * Resolve the collection map from the dependencies registered by UnpackPinDeferred().
+		 * Must be called after the referenced collections have finished loading. Idempotent.
+		 * @return HasValidMapping() -- false if a referenced collection failed to resolve.
+		 */
+		bool ResolveDeferred(FPCGExContext* InContext);
 
 		/**
 		 * Build point partitions from point data.

--- a/Source/PCGExCore/Private/Helpers/PCGExStreamingHelpers.cpp
+++ b/Source/PCGExCore/Private/Helpers/PCGExStreamingHelpers.cpp
@@ -18,6 +18,19 @@ namespace PCGExHelpers
 		// Thread-safe synchronous asset loading. UAssetManager requires game-thread access,
 		// so when called from a worker thread, dispatch to game thread and block until complete.
 		// The context tracks the handle to prevent premature GC of loaded assets.
+		//
+		// DEADLOCK WARNING: "AnyThread" means callable from any thread, NOT completable without the
+		// game thread -- the off-thread branch below marshals to the game thread and blocks
+		// (ExecuteOnMainThreadAndWait). The streamable manager structurally requires the game thread
+		// to complete a load (FlushAsyncLoading is GT/ALT-only; FStreamableHandle completion and
+		// release are game-thread-only), so this cannot be made truly worker-completable.
+		// Therefore: DO NOT call this from a path that the task can be cancelled mid-flight on a worker
+		// (e.g. a PCGEx element's Boot()/Execute()). PCG's FPCGGraphExecutor::Cancel() blocks the game
+		// thread waiting on that worker task BEFORE it calls Abort(), so the game thread never services
+		// the marshaled load -> the worker waits on the GT, the GT waits on the worker -> hard deadlock.
+		// For those paths use the async dependency flow instead: FPCGExContext::AddAssetDependency()
+		// during prepare (which pauses the context, so Cancel() takes PCG's no-wait paused-task path),
+		// or PCGExHelpers::Load() / FPickUnpacker::UnpackPinDeferred() + ResolveDeferred().
 		TSharedPtr<FStreamableHandle> Handle;
 		if (IsInGameThread())
 		{
@@ -40,6 +53,9 @@ namespace PCGExHelpers
 
 	TSharedPtr<FStreamableHandle> LoadBlocking_AnyThread(const TSharedPtr<TSet<FSoftObjectPath>>& Paths, FPCGExContext* InContext)
 	{
+		// DEADLOCK WARNING: see the single-path overload above. Off the game thread this marshals to
+		// the GT and blocks, so it must not be used on a worker path that can be cancelled mid-flight
+		// (PCGEx element Boot()/Execute()). Prefer the async dependency flow there.
 		TSharedPtr<FStreamableHandle> Handle;
 		if (IsInGameThread())
 		{


### PR DESCRIPTION
# Fix: deadlock when cancelling PCG generation that runs `FPickUnpacker` collection loads

## Summary

Moving a PCG generation source quickly through the world (spawning many concurrent
generate/cleanup tasks) could hard-deadlock the editor. The game thread would hang in
`FPCGGraphExecutor::Cancel()` waiting on a worker task that was itself blocked loading a
collection asset.

Root cause: several PCG nodes resolve their "Collection Map" by calling the **blocking**
`FPickUnpacker::UnpackPin()` from a worker-thread element phase. The blocking load marshals
to the game thread and waits — but the game thread is parked inside `Cancel()` waiting on
that very worker task, so neither side can proceed.

This PR makes the collection-map nodes load their collections **asynchronously / on the game
thread** so the load can never deadlock a mid-flight cancel, adds a cancel-safe deferred API
to `FPickUnpacker`, and documents the hazard on `LoadBlocking_AnyThread`.

## The deadlock

<img width="695" height="1474" alt="PCGEx-DeadlockOnCancelDuringLoadWait" src="https://github.com/user-attachments/assets/0bcdd348-7820-4015-9346-a38ce9a03e6d" />



1. PCG's `Cancel()` marks the active task cancelled, then **waits on the task to finish
   before calling `Element->Abort()`** (wait-then-abort ordering).
2. The worker task can only finish once its blocking asset load completes.
3. The asset load is marshaled to the game thread (`UAssetManager` / the streamable manager
   require the game thread to complete a load — `FlushAsyncLoading` is game/async-loading-thread
   only, and `FStreamableHandle` completion/release are game-thread-only).
4. The game thread never services that marshaled load because it is parked in `Cancel()`’s
   wait.

Worker waits on the game thread; the game thread waits on the worker. Deadlock.

## Fix

### 1. `FPickUnpacker` — add a cancel-safe deferred load path

`UnpackDataset` was split into two reusable halves:

- `CollectDataset(...)` — validate the attribute set and accumulate the
  `CollectionIdx → soft path` picks. **No loading.**
- `BuildResolvedMap(...)` — resolve the (already-loaded) soft paths into the live
  `CollectionMap`. Idempotent.

New public API:

- `UnpackPinDeferred(FPCGExContext*, FName)` — collects picks and registers the referenced
  collections as **async asset dependencies** on the context
  (`FPCGExContext::AddAssetDependency`). Non-blocking. The element’s normal asset-loading phase
  then streams them in **with the context paused**, so a concurrent `Cancel()` resolves through
  PCG’s **no-wait paused-task path** instead of blocking the game thread on a worker.
- `ResolveDeferred(FPCGExContext*)` — builds the map once the dependencies are loaded.
- `HasCollectedPicks()` — Boot-time validity check ("a Map input was found"), distinct from
  `HasValidMapping()` ("the live collection map is built").

The blocking `UnpackPin` / `UnpackDataset` are retained **unchanged in behavior** for callers
that legitimately run on the game thread or in non-cancellable contexts (e.g. mesh selectors).

### 2. `LoadBlocking_AnyThread` — document the hazard

Added a prominent warning: `_AnyThread` means *callable* from any thread, **not** *completable*
without the game thread. It must not be used on a worker path that can be cancelled mid-flight;
use the async dependency flow instead.

### 3. Consuming nodes — adopt the deferred path

PCGEx framework nodes (`FPCGExContext`-based) converted to
`UnpackPinDeferred` (Boot) + `ResolveDeferred` (start of initial execution, before batch
processing) + `HasCollectedPicks` for the Boot validity check:

- `PCGExStagingLoadProperties`
- `PCGExStagingLoadPCGData`



## Files changed

PCGExtendedToolkit:

- `Source/PCGExCollections/Public/Helpers/PCGExCollectionsHelpers.h` — deferred API,
  `HasCollectedPicks()`, `CollectedCollectionPaths` member, `CollectDataset` / `BuildResolvedMap`.
- `Source/PCGExCollections/Private/Helpers/PCGExCollectionsHelpers.cpp` — refactor +
  `UnpackPinDeferred` / `ResolveDeferred`.
- `Source/PCGExCore/Private/Helpers/PCGExStreamingHelpers.cpp` — deadlock warning on both
  `LoadBlocking_AnyThread` overloads.
- `Source/PCGExCollections/Private/Elements/PCGExStagingLoadProperties.cpp` — deferred adoption.
- `Source/PCGExCollections/Private/Elements/PCGExStagingLoadPCGData.cpp` — deferred adoption.

## Behavior notes

- Inconsistent maps (the same `CollectionIdx` resolving to different collection paths) now fail
  **closed** during collect — an empty map and a clean Boot error — rather than proceeding with a
  partially built map. This only affects an error path.
- No functional change to the blocking `UnpackPin` callers that already run on the game thread.

## Testing

- Reproduced the original hang by moving the runtime generation source quickly (many concurrent
  generate/cancel tasks) and confirmed the editor deadlocked in `FPCGGraphExecutor::Cancel()`.
- After the change, the same stress pattern cancels cleanly with no hang.

## Out of scope / known remaining

- There are 6 remaining PCGEx staging nodes  that still call the blocking `UnpackPin` (same straightforward recipe).
> (`StagingFitting`, `StagingLoadLevel`, `StagingLoadSockets`, `StagingSpawnActors`,
> `StagingTypeFilter`, `StagingSplineMesh`) share the same pattern and can be swept with the
> same recipe in a follow-up.