### PR TITLE
[Core] Migrated PCGExFactory::EType enum to native type IDs

### DIFF
--- a/Source/PCGExBlending/Public/Core/PCGExBlendOpFactory.h
+++ b/Source/PCGExBlending/Public/Core/PCGExBlendOpFactory.h
@@ -216,11 +216,6 @@ public:
 	TSharedPtr<PCGExData::FFacade> ConstantA;
 	TSharedPtr<PCGExData::FFacade> ConstantB;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Blending;
-	}
-
 	virtual bool IsMonolithic() const
 	{
 		return false;

--- a/Source/PCGExBlending/Public/Core/PCGExBlendOpFactoryProvider.h
+++ b/Source/PCGExBlending/Public/Core/PCGExBlendOpFactoryProvider.h
@@ -58,7 +58,7 @@ public:
 	virtual TArray<FPCGPreConfiguredSettingsInfo> GetPreconfiguredInfo() const override;
 #endif
 
-	//PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, true)
+	//PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), true)
 
 	PCGEX_FACTORY_TYPE_ID(FPCGExDataTypeInfoBlendOp)
 

--- a/Source/PCGExCollections/Private/Elements/PCGExStagingDistribute.cpp
+++ b/Source/PCGExCollections/Private/Elements/PCGExStagingDistribute.cpp
@@ -174,7 +174,7 @@ bool FPCGExAssetStagingElement::Boot(FPCGExContext* InContext) const
 	if (Settings->SelectorMode != EPCGExSelectorMode::Legacy)
 	{
 		TArray<TObjectPtr<const UPCGExSelectorFactoryData>> Factories;
-		if (!PCGExFactories::GetInputFactories<UPCGExSelectorFactoryData>(Context, PCGExCollections::Labels::SourceSelectorLabel, Factories, {PCGExFactories::EType::Selector}))
+		if (!PCGExFactories::GetInputFactories<UPCGExSelectorFactoryData>(Context, PCGExCollections::Labels::SourceSelectorLabel, Factories, {FPCGExDataTypeInfoSelector::AsId()}))
 		{
 			PCGE_LOG(Error, GraphAndLog, FTEXT("External distribution mode requires a Selector factory on the Selector input pin."));
 			return false;

--- a/Source/PCGExCollections/Private/Elements/PCGExStagingSplineMesh.cpp
+++ b/Source/PCGExCollections/Private/Elements/PCGExStagingSplineMesh.cpp
@@ -158,7 +158,7 @@ bool FPCGExPathSplineMeshElement::Boot(FPCGExContext* InContext) const
 		if (Settings->SelectorMode != EPCGExSelectorMode::Legacy)
 		{
 			TArray<TObjectPtr<const UPCGExSelectorFactoryData>> Factories;
-			if (!PCGExFactories::GetInputFactories<UPCGExSelectorFactoryData>(Context, PCGExCollections::Labels::SourceSelectorLabel, Factories, {PCGExFactories::EType::Selector}))
+			if (!PCGExFactories::GetInputFactories<UPCGExSelectorFactoryData>(Context, PCGExCollections::Labels::SourceSelectorLabel, Factories, {FPCGExDataTypeInfoSelector::AsId()}))
 			{
 				PCGE_LOG(Error, GraphAndLog, FTEXT("External distribution mode requires a Selector factory on the Selector input pin."));
 				return false;

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingDistribute.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingDistribute.h
@@ -103,7 +103,7 @@ protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual void InputPinPropertiesBeforeFilters(TArray<FPCGPinProperties>& PinProperties) const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get staged.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get staged.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 public:

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingFitting.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingFitting.h
@@ -59,7 +59,7 @@ protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual void InputPinPropertiesBeforeFilters(TArray<FPCGPinProperties>& PinProperties) const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get fitted.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get fitted.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 public:

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingLoadLevel.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingLoadLevel.h
@@ -122,7 +122,7 @@ public:
 protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual void InputPinPropertiesBeforeFilters(TArray<FPCGPinProperties>& PinProperties) const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points spawn a level instance.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points spawn a level instance.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 	virtual bool IsCacheable() const override

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingLoadPCGData.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingLoadPCGData.h
@@ -78,7 +78,7 @@ public:
 	}
 #endif
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 protected:
 	virtual bool OutputPinsCanBeDeactivated() const override

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingLoadProperties.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingLoadProperties.h
@@ -41,7 +41,7 @@ public:
 protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual void InputPinPropertiesBeforeFilters(TArray<FPCGPinProperties>& PinProperties) const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get properties.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get properties.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 	virtual bool SupportsDataStealing() const override

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingLoadSockets.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingLoadSockets.h
@@ -42,7 +42,7 @@ protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual void InputPinPropertiesBeforeFilters(TArray<FPCGPinProperties>& PinProperties) const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get staged.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get staged.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 public:

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingSpawnActors.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingSpawnActors.h
@@ -50,7 +50,7 @@ protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual void InputPinPropertiesBeforeFilters(TArray<FPCGPinProperties>& PinProperties) const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points spawn an actor.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points spawn an actor.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 	virtual bool IsCacheable() const override

--- a/Source/PCGExCollections/Public/Elements/PCGExStagingSplineMesh.h
+++ b/Source/PCGExCollections/Public/Elements/PCGExStagingSplineMesh.h
@@ -83,7 +83,7 @@ protected:
 	virtual PCGExData::EIOInit GetMainDataInitializationPolicy() const override;
 
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable))
 	bool bUseStagedPoints = true;

--- a/Source/PCGExCollections/Public/Selectors/PCGExSelectorFactoryProvider.h
+++ b/Source/PCGExCollections/Public/Selectors/PCGExSelectorFactoryProvider.h
@@ -51,11 +51,6 @@ public:
 	UPROPERTY()
 	FPCGExSelectorFactoryBaseConfig BaseConfig;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Selector;
-	}
-
 	/** Create a hot-path entry picker operation. Concrete subclasses override. */
 	virtual TSharedPtr<FPCGExEntryPickerOperation> CreateEntryOperation(FPCGExContext* InContext) const;
 

--- a/Source/PCGExCore/Private/Factories/PCGExFactories.cpp
+++ b/Source/PCGExCore/Private/Factories/PCGExFactories.cpp
@@ -15,7 +15,7 @@
 
 namespace PCGExFactories
 {
-	bool GetInputFactories_Internal(FPCGExContext* InContext, const FName InLabel, TArray<TObjectPtr<const UPCGExFactoryData>>& OutFactories, const TSet<EType>& Types, const bool bRequired)
+	bool GetInputFactories_Internal(FPCGExContext* InContext, const FName InLabel, TArray<TObjectPtr<const UPCGExFactoryData>>& OutFactories, const TSet<FPCGDataTypeBaseId>& Types, const bool bRequired)
 	{
 		const TArray<FPCGTaggedData>& Inputs = InContext->InputData.GetInputsByPin(InLabel);
 		TSet<uint32> UniqueData;
@@ -33,7 +33,7 @@ namespace PCGExFactories
 			const UPCGExFactoryData* Factory = Cast<UPCGExFactoryData>(TaggedData.Data);
 			if (Factory)
 			{
-				if (!Types.Contains(Factory->GetFactoryType()))
+				if (!Types.Contains(Factory->GetDataTypeId()))
 				{
 					PCGEX_LOG_INVALID_INPUT(InContext, FText::Format(FTEXT("Input '{0}' is not supported by pin {1}."), FText::FromString(TaggedData.Data->GetClass()->GetName()), FText::FromName(InLabel)))
 					continue;

--- a/Source/PCGExCore/Private/Sorting/PCGExSortingDetails.cpp
+++ b/Source/PCGExCore/Private/Sorting/PCGExSortingDetails.cpp
@@ -27,7 +27,7 @@ namespace PCGExSorting
 	{
 		TArray<FPCGExSortRuleConfig> OutRules;
 		TArray<TObjectPtr<const UPCGExSortingRule>> Factories;
-		if (!PCGExFactories::GetInputFactories(InContext, InLabel, Factories, {PCGExFactories::EType::RuleSort}, false))
+		if (!PCGExFactories::GetInputFactories(InContext, InLabel, Factories, {FPCGExDataTypeInfoSortRule::AsId()}, false))
 		{
 			return OutRules;
 		}

--- a/Source/PCGExCore/Public/Factories/PCGExFactories.h
+++ b/Source/PCGExCore/Public/Factories/PCGExFactories.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
+#include "Data/Registry/PCGDataType.h"
 
 ///
 
@@ -23,37 +24,6 @@ struct FPCGExFactoryProviderContext;
 
 namespace PCGExFactories
 {
-	enum class EType : uint8
-	{
-		None = 0,
-		Instanced,
-		Filter,
-		FilterGroup,
-		FilterPoint,
-		FilterNode,
-		FilterEdge,
-		FilterCollection,
-		RuleSort,
-		RulePartition,
-		Probe,
-		ClusterState,
-		PointState,
-		Sampler,
-		Heuristics,
-		VtxProperty,
-		Action,
-		ShapeBuilder,
-		Blending,
-		TexParam,
-		Tensor,
-		IndexPicker,
-		FillControls,
-		MatchRule,
-		Noise3D,
-		Selector,
-		ValencyBias
-	};
-
 	enum class EPreparationResult : uint8
 	{
 		None = 0,
@@ -62,24 +32,15 @@ namespace PCGExFactories
 		Fail
 	};
 
-	static inline TSet<EType> AnyFilters = {EType::FilterPoint, EType::FilterNode, EType::FilterEdge, EType::FilterGroup, EType::FilterCollection};
-	static inline TSet<EType> PointFilters = {EType::FilterPoint, EType::FilterGroup, EType::FilterCollection};
-	static inline TSet<EType> ClusterNodeFilters = {EType::FilterPoint, EType::FilterNode, EType::FilterGroup, EType::FilterCollection};
-	static inline TSet<EType> ClusterEdgeFilters = {EType::FilterPoint, EType::FilterEdge, EType::FilterGroup, EType::FilterCollection};
-	static inline TSet<EType> SupportsClusterFilters = {EType::FilterEdge, EType::FilterNode, EType::ClusterState, EType::FilterGroup, EType::FilterCollection};
-	static inline TSet<EType> ClusterOnlyFilters = {EType::FilterEdge, EType::FilterNode, EType::ClusterState};
-	static inline TSet<EType> ClusterStates = {EType::ClusterState, EType::PointState};
 }
-
-// TODO : Move this to helper class
 
 namespace PCGExFactories
 {
 	PCGEXCORE_API
-	bool GetInputFactories_Internal(FPCGExContext* InContext, const FName InLabel, TArray<TObjectPtr<const UPCGExFactoryData>>& OutFactories, const TSet<EType>& Types, const bool bRequired);
+	bool GetInputFactories_Internal(FPCGExContext* InContext, const FName InLabel, TArray<TObjectPtr<const UPCGExFactoryData>>& OutFactories, const TSet<FPCGDataTypeBaseId>& Types, const bool bRequired);
 
 	template <typename T_DEF>
-	static bool GetInputFactories(FPCGExContext* InContext, const FName InLabel, TArray<TObjectPtr<const T_DEF>>& OutFactories, const TSet<EType>& Types, const bool bRequired = true)
+	static bool GetInputFactories(FPCGExContext* InContext, const FName InLabel, TArray<TObjectPtr<const T_DEF>>& OutFactories, const TSet<FPCGDataTypeBaseId>& Types, const bool bRequired = true)
 	{
 		TArray<TObjectPtr<const UPCGExFactoryData>> BaseFactories;
 		if (!GetInputFactories_Internal(InContext, InLabel, BaseFactories, Types, bRequired))

--- a/Source/PCGExCore/Public/Factories/PCGExFactoryData.h
+++ b/Source/PCGExCore/Public/Factories/PCGExFactoryData.h
@@ -77,11 +77,6 @@ public:
 
 	PCGExFactories::EPreparationResult PrepResult = PCGExFactories::EPreparationResult::None;
 
-	virtual PCGExFactories::EType GetFactoryType() const
-	{
-		return PCGExFactories::EType::None;
-	}
-
 	virtual bool RegisterConsumableAttributes(FPCGExContext* InContext) const;
 	virtual bool RegisterConsumableAttributesWithData(FPCGExContext* InContext, const UPCGData* InData) const;
 	virtual void RegisterAssetDependencies(TSet<FSoftObjectPath>& InDependencies) const;

--- a/Source/PCGExCore/Public/PCGExCoreMacros.h
+++ b/Source/PCGExCore/Public/PCGExCoreMacros.h
@@ -161,7 +161,7 @@ virtual FText GetNodeTooltipText() const override{ return FTEXT(_TOOLTIP); }
 #define PCGEX_NODE_POINT_FILTER(_LABEL, _TOOLTIP, _TYPE, _REQUIRED) \
 virtual FName GetPointFilterPin() const override { return _LABEL; } \
 virtual FString GetPointFilterTooltip() const override { return TEXT(_TOOLTIP); } \
-virtual TSet<PCGExFactories::EType> GetPointFilterTypes() const override { return _TYPE; } \
+virtual TSet<FPCGDataTypeBaseId> GetPointFilterTypes() const override { return _TYPE; } \
 virtual bool RequiresPointFilters() const override { return _REQUIRED; }
 
 

--- a/Source/PCGExCore/Public/Sorting/PCGExSortingRuleProvider.h
+++ b/Source/PCGExCore/Public/Sorting/PCGExSortingRuleProvider.h
@@ -34,11 +34,6 @@ class PCGEXCORE_API UPCGExSortingRule : public UPCGExFactoryData
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoSortRule)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::RuleSort;
-	}
-
 	FPCGExSortRuleConfig Config;
 
 	virtual bool RegisterConsumableAttributesWithData(FPCGExContext* InContext, const UPCGData* InData) const override;

--- a/Source/PCGExElementsActions/Private/Core/PCGExActionFactoryProvider.cpp
+++ b/Source/PCGExElementsActions/Private/Core/PCGExActionFactoryProvider.cpp
@@ -5,6 +5,7 @@
 
 
 #include "PCGPin.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/Utils/PCGExDataFilterDetails.h"
 #include "Types/PCGExAttributeIdentity.h"
@@ -128,7 +129,7 @@ UPCGExFactoryData* UPCGExActionProviderSettings::CreateFactory(FPCGExContext* In
 
 	if (UPCGExActionFactoryData* TypedFactory = Cast<UPCGExActionFactoryData>(InFactory))
 	{
-		if (!GetInputFactories(InContext, PCGExActions::Labels::SourceConditionsFilterLabel, TypedFactory->FilterFactories, PCGExFactories::PointFilters))
+		if (!PCGExFactories::GetInputFactories(InContext, PCGExActions::Labels::SourceConditionsFilterLabel, TypedFactory->FilterFactories, PCGExFactories::PointFilters()))
 		{
 			return nullptr;
 		}

--- a/Source/PCGExElementsActions/Private/Elements/PCGExBatchActions.cpp
+++ b/Source/PCGExElementsActions/Private/Elements/PCGExBatchActions.cpp
@@ -47,7 +47,7 @@ bool FPCGExBatchActionsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(BatchActions)
 
-	if (!PCGExFactories::GetInputFactories(Context, PCGExActions::Labels::SourceActionsLabel, Context->ActionsFactories, {PCGExFactories::EType::Action}))
+	if (!PCGExFactories::GetInputFactories(Context, PCGExActions::Labels::SourceActionsLabel, Context->ActionsFactories, {FPCGExDataTypeInfoAction::AsId()}))
 	{
 		// No action factories, early exit.
 		Context->ActionsFactories.Empty();

--- a/Source/PCGExElementsActions/Public/Core/PCGExActionFactoryProvider.h
+++ b/Source/PCGExElementsActions/Public/Core/PCGExActionFactoryProvider.h
@@ -82,11 +82,6 @@ public:
 	UPROPERTY(meta=(PCG_NotOverridable))
 	TArray<TObjectPtr<const UPCGExPointFilterFactoryData>> FilterFactories;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Action;
-	}
-
 	virtual TSharedPtr<FPCGExActionOperation> CreateOperation(FPCGExContext* InContext) const;
 
 	virtual bool Boot(FPCGContext* InContext);

--- a/Source/PCGExElementsClusters/Private/Elements/Meta/NeighborSamplers/PCGExNeighborSampleBlend.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Meta/NeighborSamplers/PCGExNeighborSampleBlend.cpp
@@ -111,7 +111,7 @@ UPCGExFactoryData* UPCGExNeighborSampleBlendSettings::CreateFactory(FPCGExContex
 {
 	UPCGExNeighborSamplerFactoryBlend* SamplerFactory = InContext->ManagedObjects->New<UPCGExNeighborSamplerFactoryBlend>();
 
-	if (!PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(InContext, PCGExBlending::Labels::SourceBlendingLabel, SamplerFactory->BlendingFactories, {PCGExFactories::EType::Blending}))
+	if (!PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(InContext, PCGExBlending::Labels::SourceBlendingLabel, SamplerFactory->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}))
 	{
 		InContext->ManagedObjects->Destroy(SamplerFactory);
 		return nullptr;

--- a/Source/PCGExElementsClusters/Private/Elements/Meta/NeighborSamplers/PCGExNeighborSampleFactoryProvider.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Meta/NeighborSamplers/PCGExNeighborSampleFactoryProvider.cpp
@@ -5,6 +5,7 @@
 
 #include "PCGPin.h"
 #include "Clusters/PCGExCluster.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Data/PCGExData.h"
 
 
@@ -28,14 +29,14 @@ void FPCGExNeighborSampleOperation::PrepareForCluster(FPCGExContext* InContext, 
 	if (!VtxFilterFactories.IsEmpty())
 	{
 		PointFilters = MakeShared<PCGExClusterFilter::FManager>(InCluster, InVtxDataFacade, InEdgeDataFacade);
-		PointFilters->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+		PointFilters->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 		PointFilters->Init(InContext, VtxFilterFactories);
 	}
 
 	if (!ValueFilterFactories.IsEmpty())
 	{
 		ValueFilters = MakeShared<PCGExClusterFilter::FManager>(InCluster, InVtxDataFacade, InEdgeDataFacade);
-		ValueFilters->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+		ValueFilters->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 		ValueFilters->Init(InContext, ValueFilterFactories);
 	}
 }
@@ -286,11 +287,11 @@ UPCGExFactoryData* UPCGExNeighborSampleProviderSettings::CreateFactory(FPCGExCon
 	SamplerFactory->SamplingConfig = SamplingConfig;
 	SamplerFactory->SamplingConfig.Init();
 
-	GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, SamplerFactory->VtxFilterFactories, PCGExFactories::ClusterNodeFilters, false);
+	PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, SamplerFactory->VtxFilterFactories, PCGExFactories::ClusterNodeFilters(), false);
 
-	GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, SamplerFactory->EdgesFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+	PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, SamplerFactory->EdgesFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 
-	GetInputFactories(InContext, PCGExFilters::Labels::SourceUseValueIfFilters, SamplerFactory->ValueFilterFactories, PCGExFactories::ClusterNodeFilters, false);
+	PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceUseValueIfFilters, SamplerFactory->ValueFilterFactories, PCGExFactories::ClusterNodeFilters(), false);
 
 	return Super::CreateFactory(InContext, SamplerFactory);
 }

--- a/Source/PCGExElementsClusters/Private/Elements/Meta/NeighborSamplers/PCGExNeighborSampleFilters.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Meta/NeighborSamplers/PCGExNeighborSampleFilters.cpp
@@ -5,6 +5,7 @@
 
 #include "Clusters/PCGExCluster.h"
 #include "Containers/PCGExManagedObjects.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Data/PCGExData.h"
 #include "Helpers/PCGExMetaHelpers.h"
 
@@ -87,7 +88,7 @@ void FPCGExNeighborSampleFilters::PrepareForCluster(FPCGExContext* InContext, co
 
 	if (SamplingConfig.NeighborSource == EPCGExClusterElement::Vtx)
 	{
-		FilterManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+		FilterManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 		if (!FilterManager->Init(InContext, VtxFilterFactories))
 		{
 			return;
@@ -96,7 +97,7 @@ void FPCGExNeighborSampleFilters::PrepareForCluster(FPCGExContext* InContext, co
 	else
 	{
 		FilterManager->bUseEdgeAsPrimary = true;
-		FilterManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters);
+		FilterManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters());
 		if (!FilterManager->Init(InContext, EdgesFilterFactories))
 		{
 			return;

--- a/Source/PCGExElementsClusters/Private/Elements/Meta/PCGExSampleNeighbors.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Meta/PCGExSampleNeighbors.cpp
@@ -41,7 +41,7 @@ bool FPCGExSampleNeighborsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(SampleNeighbors)
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExNeighborSample::SourceSamplersLabel, Context->SamplerFactories, {PCGExFactories::EType::Sampler}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExNeighborSample::SourceSamplersLabel, Context->SamplerFactories, {FPCGExDataTypeInfoNeighborSampler::AsId()}))
 	{
 		return false;
 	}

--- a/Source/PCGExElementsClusters/Private/Elements/Meta/PCGExWriteEdgeProperties.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Meta/PCGExWriteEdgeProperties.cpp
@@ -66,7 +66,7 @@ bool FPCGExWriteEdgePropertiesElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->bEndpointsBlending && Settings->BlendingInterface == EPCGExBlendingInterface::Individual)
 	{
-		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 	}
 
 	return true;

--- a/Source/PCGExElementsClusters/Private/Elements/Meta/PCGExWriteVtxProperties.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Meta/PCGExWriteVtxProperties.cpp
@@ -51,7 +51,7 @@ bool FPCGExWriteVtxPropertiesElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_FOREACH_FIELD_VTXEXTRAS(PCGEX_OUTPUT_VALIDATE_NAME)
 
-	PCGExFactories::GetInputFactories(InContext, PCGExVtxProperty::SourcePropertyLabel, Context->ExtraFactories, {PCGExFactories::EType::VtxProperty}, false);
+	PCGExFactories::GetInputFactories(InContext, PCGExVtxProperty::SourcePropertyLabel, Context->ExtraFactories, {FPCGExDataTypeInfoVtxProperty::AsId()}, false);
 
 	return true;
 }

--- a/Source/PCGExElementsClusters/Private/Elements/PCGExClusterCentrality.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/PCGExClusterCentrality.cpp
@@ -7,6 +7,7 @@
 #include "PCGParamData.h"
 #include "Clusters/PCGExCluster.h"
 #include "Containers/PCGExScopedContainers.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExHeuristicsFactoryProvider.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/PCGExData.h"
@@ -92,7 +93,7 @@ bool FPCGExClusterCentralityElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->IsPathBased() && Settings->DownsamplingMode == EPCGExCentralityDownsampling::Filters)
 	{
-		if (!GetInputFactories(Context, PCGExClusters::Labels::SourceVtxFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters))
+		if (!PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceVtxFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters()))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsClusters/Private/Elements/PCGExConnectClusters.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/PCGExConnectClusters.cpp
@@ -5,6 +5,7 @@
 
 #include "Clusters/PCGExCluster.h"
 #include "Clusters/PCGExClustersHelpers.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExDataTags.h"
@@ -65,11 +66,11 @@ bool FPCGExConnectClustersElement::Boot(FPCGExContext* InContext) const
 		/*
 		if (!GetInputFactories(
 			Context, PCGExClusters::Labels::SourceFilterGenerators, Context->GeneratorsFiltersFactories,
-			PCGExFactories::ClusterNodeFilters, true)) { return false; }
+			PCGExFactories::ClusterNodeFilters(), true)) { return false; }
 
 		if (!GetInputFactories(
 			Context, PCGExClusters::Labels::SourceFilterConnectables, Context->ConnectablesFiltersFactories,
-			PCGExFactories::ClusterNodeFilters, true)) { return false; }
+			PCGExFactories::ClusterNodeFilters(), true)) { return false; }
 		*/
 	}
 

--- a/Source/PCGExElementsClusters/Private/Elements/PCGExFilterVtx.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/PCGExFilterVtx.cpp
@@ -9,6 +9,7 @@
 #include "Clusters/PCGExCluster.h"
 #include "Clusters/PCGExClustersHelpers.h"
 #include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
 #include "Graphs/PCGExGraph.h"
@@ -106,14 +107,14 @@ bool FPCGExFilterVtxElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_FWD(GraphBuilderDetails)
 
-	if (!GetInputFactories(Context, PCGExClusters::Labels::SourceVtxFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters))
+	if (!PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceVtxFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters()))
 	{
 		return false;
 	}
 
 	if (Settings->Mode == EPCGExVtxFilterOutput::Clusters)
 	{
-		GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+		PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 	}
 
 	if (!Context->bWantsClusters)

--- a/Source/PCGExElementsClusters/Private/Elements/PCGExSampleVtxByID.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/PCGExSampleVtxByID.cpp
@@ -74,7 +74,7 @@ bool FPCGExSampleVtxByIDElement::Boot(FPCGExContext* InContext) const
 	PCGEX_FWD(ApplySampling)
 	Context->ApplySampling.Init();
 
-	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 
 	FBox OctreeBounds = FBox(ForceInit);
 

--- a/Source/PCGExElementsClusters/Private/Elements/PCGExSimplifyClusters.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/PCGExSimplifyClusters.cpp
@@ -6,6 +6,7 @@
 #include "Clusters/PCGExCluster.h"
 #include "Clusters/Artifacts/PCGExCachedChain.h"
 #include "Clusters/Artifacts/PCGExChain.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExUnionData.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
@@ -54,7 +55,7 @@ bool FPCGExSimplifyClustersElement::Boot(FPCGExContext* InContext) const
 
 	Context->EdgeCarryOverDetails.Init();
 
-	GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 
 	return true;
 }

--- a/Source/PCGExElementsClusters/Private/Elements/Paths/PCGExBreakClustersToPaths.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Paths/PCGExBreakClustersToPaths.cpp
@@ -7,6 +7,7 @@
 #include "Clusters/PCGExClustersHelpers.h"
 #include "Clusters/Artifacts/PCGExCachedChain.h"
 #include "Clusters/Artifacts/PCGExChain.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Curve/CurveUtil.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
@@ -63,7 +64,7 @@ bool FPCGExBreakClustersToPathsElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->OperateOn == EPCGExBreakClusterOperationTarget::Paths)
 	{
-		GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+		PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 	}
 
 	return true;

--- a/Source/PCGExElementsClusters/Private/Elements/Paths/PCGExCutClusters.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/Paths/PCGExCutClusters.cpp
@@ -5,6 +5,7 @@
 
 #include "Clusters/PCGExCluster.h"
 #include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
 #include "Graphs/PCGExGraph.h"
@@ -66,12 +67,12 @@ bool FPCGExCutEdgesElement::Boot(FPCGExContext* InContext) const
 
 	if (Context->bWantsEdgesProcessing)
 	{
-		GetInputFactories(Context, PCGExCutEdges::SourceEdgeFilters, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+		PCGExFactories::GetInputFactories(Context, PCGExCutEdges::SourceEdgeFilters, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 	}
 
 	if (Context->bWantsVtxProcessing)
 	{
-		GetInputFactories(Context, PCGExCutEdges::SourceNodeFilters, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters, false);
+		PCGExFactories::GetInputFactories(Context, PCGExCutEdges::SourceNodeFilters, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters(), false);
 	}
 
 	PCGEX_MAKE_SHARED(PathCollection, PCGExData::FPointIOCollection, Context, PCGExPaths::Labels::SourcePathsLabel)

--- a/Source/PCGExElementsClusters/Private/Elements/States/PCGExClusterWriteStates.cpp
+++ b/Source/PCGExElementsClusters/Private/Elements/States/PCGExClusterWriteStates.cpp
@@ -48,7 +48,7 @@ bool FPCGExFlagNodesElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(FlagNodes)
 
-	return PCGExFactories::GetInputFactories(Context, PCGExPointStates::Labels::SourceStatesLabel, Context->StateFactories, {PCGExFactories::EType::ClusterState});
+	return PCGExFactories::GetInputFactories(Context, PCGExPointStates::Labels::SourceStatesLabel, Context->StateFactories, {FPCGExDataTypeInfoClusterState::AsId()});
 }
 
 bool FPCGExFlagNodesElement::AdvanceWork(FPCGExContext* InContext, const UPCGExSettings* InSettings) const

--- a/Source/PCGExElementsClusters/Private/Filters/Edges/PCGExEdgeEndpointsCheckFilter.cpp
+++ b/Source/PCGExElementsClusters/Private/Filters/Edges/PCGExEdgeEndpointsCheckFilter.cpp
@@ -6,6 +6,7 @@
 
 #include "Clusters/PCGExCluster.h"
 #include "Containers/PCGExManagedObjects.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Graphs/PCGExGraph.h"
 #include "HAL/PlatformAtomics.h"
 
@@ -94,7 +95,7 @@ namespace PCGExEdgeEndpointsCheck
 		}
 
 		VtxFiltersManager = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), InPointDataFacade, InEdgeDataFacade);
-		VtxFiltersManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+		VtxFiltersManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 		if (!VtxFiltersManager->Init(InContext, TypedFilterFactory->FilterFactories))
 		{
 			return false;
@@ -107,7 +108,7 @@ namespace PCGExEdgeEndpointsCheck
 		if (TypedFilterFactory->Config.bUseTwoFilterSets)
 		{
 			VtxFiltersManagerB = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), InPointDataFacade, InEdgeDataFacade);
-			VtxFiltersManagerB->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+			VtxFiltersManagerB->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 			if (!VtxFiltersManagerB->Init(InContext, TypedFilterFactory->FilterFactoriesB))
 			{
 				return false;
@@ -210,7 +211,7 @@ UPCGExFactoryData* UPCGExEdgeEndpointsCheckFilterProviderSettings::CreateFactory
 
 	Super::CreateFactory(InContext, NewFactory);
 
-	if (!GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterNodeFilters))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterNodeFilters()))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;
@@ -218,7 +219,7 @@ UPCGExFactoryData* UPCGExEdgeEndpointsCheckFilterProviderSettings::CreateFactory
 
 	if (Config.bUseTwoFilterSets)
 	{
-		if (!GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabelB, NewFactory->FilterFactoriesB, PCGExFactories::ClusterNodeFilters))
+		if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabelB, NewFactory->FilterFactoriesB, PCGExFactories::ClusterNodeFilters()))
 		{
 			InContext->ManagedObjects->Destroy(NewFactory);
 			return nullptr;

--- a/Source/PCGExElementsClusters/Public/Elements/Meta/NeighborSamplers/PCGExNeighborSampleFactoryProvider.h
+++ b/Source/PCGExElementsClusters/Public/Elements/Meta/NeighborSamplers/PCGExNeighborSampleFactoryProvider.h
@@ -168,11 +168,6 @@ public:
 	UPROPERTY()
 	TArray<TObjectPtr<const UPCGExPointFilterFactoryData>> ValueFilterFactories;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Sampler;
-	}
-
 	virtual TSharedPtr<FPCGExNeighborSampleOperation> CreateOperation(FPCGExContext* InContext) const;
 
 	virtual void RegisterVtxBuffersDependencies(FPCGExContext* InContext, const TSharedRef<PCGExData::FFacade>& InVtxDataFacade, PCGExData::FFacadePreloader& FacadePreloader) const;

--- a/Source/PCGExElementsClusters/Public/Elements/Meta/PCGExSampleNeighbors.h
+++ b/Source/PCGExElementsClusters/Public/Elements/Meta/PCGExSampleNeighbors.h
@@ -7,6 +7,7 @@
 
 
 #include "Core/PCGExClustersProcessor.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "PCGExSampleNeighbors.generated.h"
 
@@ -33,7 +34,7 @@ public:
 		return PCGEX_NODE_COLOR_NAME(Sampling);
 	}
 #endif
-	PCGEX_NODE_POINT_FILTER(PCGExClusters::Labels::SourceVtxFiltersLabel, "Optional per-node filters. Only nodes that pass the filter will be sampled; filtered-out nodes can still be read by other nodes.", PCGExFactories::ClusterNodeFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExClusters::Labels::SourceVtxFiltersLabel, "Optional per-node filters. Only nodes that pass the filter will be sampled; filtered-out nodes can still be read by other nodes.", PCGExFactories::ClusterNodeFilters(), false)
 
 protected:
 	virtual TArray<FPCGPinProperties> InputPinProperties() const override;

--- a/Source/PCGExElementsClusters/Public/Elements/Meta/VtxProperties/PCGExVtxPropertyFactoryProvider.h
+++ b/Source/PCGExElementsClusters/Public/Elements/Meta/VtxProperties/PCGExVtxPropertyFactoryProvider.h
@@ -172,11 +172,6 @@ class UPCGExVtxPropertyFactoryData : public UPCGExFactoryData
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoVtxProperty)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::VtxProperty;
-	}
-
 	virtual TSharedPtr<FPCGExVtxPropertyOperation> CreateOperation(FPCGExContext* InContext) const;
 };
 

--- a/Source/PCGExElementsClusters/Public/Elements/PCGExSampleVtxByID.h
+++ b/Source/PCGExElementsClusters/Public/Elements/PCGExSampleVtxByID.h
@@ -7,6 +7,7 @@
 #include "PCGExFilterCommon.h"
 #include "Factories/PCGExFactories.h"
 
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointsProcessor.h"
 #include "Details/PCGExBlendingDetails.h"
 #include "Math/PCGExMathAxis.h"
@@ -64,7 +65,7 @@ protected:
 	//~Begin UPCGExPointsProcessorSettings
 
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 	//~End UPCGExPointsProcessorSettings
 

--- a/Source/PCGExElementsClusters/Public/Elements/PCGExSimplifyClusters.h
+++ b/Source/PCGExElementsClusters/Public/Elements/PCGExSimplifyClusters.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "Core/PCGExClustersProcessor.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Details/PCGExBlendingDetails.h"
 #include "Details/PCGExIntersectionDetails.h"
@@ -55,7 +56,7 @@ protected:
 public:
 	virtual PCGExData::EIOInit GetMainOutputInitMode() const override;
 	virtual PCGExData::EIOInit GetEdgeOutputInitMode() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceKeepConditionLabel, "Prevents vtx from being pruned by the simplification process", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceKeepConditionLabel, "Prevents vtx from being pruned by the simplification process", PCGExFactories::PointFilters(), false)
 	//~End UPCGExClustersProcessorSettings interface
 
 	/** If enabled, only check for dead ends. */

--- a/Source/PCGExElementsClusters/Public/Elements/Paths/PCGExBreakClustersToPaths.h
+++ b/Source/PCGExElementsClusters/Public/Elements/Paths/PCGExBreakClustersToPaths.h
@@ -8,6 +8,7 @@
 #include "PCGExFilterCommon.h"
 
 #include "Core/PCGExClustersProcessor.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Math/PCGExWinding.h"
 
@@ -64,7 +65,7 @@ public:
 
 	virtual PCGExData::EIOInit GetMainOutputInitMode() const override;
 	virtual PCGExData::EIOInit GetEdgeOutputInitMode() const override;
-	PCGEX_NODE_POINT_FILTER(FName("Break Conditions"), "Filters used to know which points are 'break' points.", PCGExFactories::ClusterNodeFilters, false)
+	PCGEX_NODE_POINT_FILTER(FName("Break Conditions"), "Filters used to know which points are 'break' points.", PCGExFactories::ClusterNodeFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** How to handle leaves */

--- a/Source/PCGExElementsClustersRefine/Private/Elements/PCGExRefineEdges.cpp
+++ b/Source/PCGExElementsClustersRefine/Private/Elements/PCGExRefineEdges.cpp
@@ -8,6 +8,7 @@
 #include "PCGParamData.h"
 #include "Async/ParallelFor.h"
 #include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
 #include "Graphs/PCGExGraph.h"
@@ -143,13 +144,13 @@ bool FPCGExRefineEdgesElement::Boot(FPCGExContext* InContext) const
 
 	if (Context->Refinement->SupportFilters())
 	{
-		//GetInputFactories(Context, PCGExRefineEdges::SourceVtxFilters, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters, false);
-		GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+		//GetInputFactories(Context, PCGExRefineEdges::SourceVtxFilters, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters(), false);
+		PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeFiltersLabel, Context->EdgeFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 	}
 
 	if (Settings->Sanitization == EPCGExRefineSanitization::Filters)
 	{
-		if (!GetInputFactories(Context, PCGExRefineEdges::SourceSanitizeEdgeFilters, Context->SanitizationFilterFactories, PCGExFactories::ClusterEdgeFilters))
+		if (!PCGExFactories::GetInputFactories(Context, PCGExRefineEdges::SourceSanitizeEdgeFilters, Context->SanitizationFilterFactories, PCGExFactories::ClusterEdgeFilters()))
 		{
 			return false;
 		}
@@ -369,7 +370,7 @@ namespace PCGExRefineEdges
 			{
 				SanitizationFilterManager = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), VtxDataFacade, EdgeDataFacade);
 				SanitizationFilterManager->bUseEdgeAsPrimary = true;
-				SanitizationFilterManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters);
+				SanitizationFilterManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters());
 				if (!SanitizationFilterManager->Init(ExecutionContext, Context->SanitizationFilterFactories))
 				{
 					return false;

--- a/Source/PCGExElementsClustersRelax/Private/Elements/PCGExRelaxClusters.cpp
+++ b/Source/PCGExElementsClustersRelax/Private/Elements/PCGExRelaxClusters.cpp
@@ -6,6 +6,7 @@
 
 #include "PCGParamData.h"
 #include "Containers/PCGExScopedContainers.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Core/PCGExRelaxClusterOperation.h"
 #include "Data/PCGExData.h"
@@ -48,7 +49,7 @@ bool FPCGExRelaxClustersElement::Boot(FPCGExContext* InContext) const
 	PCGEX_FOREACH_FIELD_RELAX_CLUSTER(PCGEX_OUTPUT_VALIDATE_NAME)
 	PCGEX_BIND_INSTANCED_FACTORY(Relaxing, UPCGExRelaxClusterOperation, PCGExRelaxClusters::SourceOverridesRelaxing)
 
-	GetInputFactories(Context, PCGExClusters::Labels::SourceVtxFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceVtxFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters(), false);
 
 	return true;
 }

--- a/Source/PCGExElementsFloodFill/Private/Elements/PCGExBFSDepth.cpp
+++ b/Source/PCGExElementsFloodFill/Private/Elements/PCGExBFSDepth.cpp
@@ -5,6 +5,7 @@
 
 #include "Clusters/PCGExCluster.h"
 #include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Data/PCGExData.h"
 #include "Factories/PCGExFactories.h"
 
@@ -60,7 +61,7 @@ bool FPCGExBFSDepthElement::Boot(FPCGExContext* InContext) const
 	if (Settings->TriggerCount.bOutputTriggerCount)
 	{
 		// Required: trigger count is meaningless without filters defining what a trigger is.
-		if (!PCGExFactories::GetInputFactories(Context, PCGExBFSDepth::Labels::SourceTriggerFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters))
+		if (!PCGExFactories::GetInputFactories(Context, PCGExBFSDepth::Labels::SourceTriggerFiltersLabel, Context->VtxFilterFactories, PCGExFactories::ClusterNodeFilters()))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsFloodFill/Private/Elements/PCGExFloodFillClusters.cpp
+++ b/Source/PCGExElementsFloodFill/Private/Elements/PCGExFloodFillClusters.cpp
@@ -77,10 +77,10 @@ bool FPCGExClusterDiffusionElement::Boot(FPCGExContext* InContext) const
 	Context->EdgeDirectionOutput = Settings->EdgeDirectionOutput;
 	Context->EdgeDirectionOutput.ValidateNames(Context);
 
-	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 
 	// Fill controls are optional
-	PCGExFactories::GetInputFactories<UPCGExFillControlsFactoryData>(Context, PCGExFloodFill::SourceFillControlsLabel, Context->FillControlFactories, {PCGExFactories::EType::FillControls}, false);
+	PCGExFactories::GetInputFactories<UPCGExFillControlsFactoryData>(Context, PCGExFloodFill::SourceFillControlsLabel, Context->FillControlFactories, {FPCGExDataTypeInfoFillControl::AsId()}, false);
 
 	// Check for deprecated Heuristics pin usage
 	if (Context->bHasValidHeuristics)

--- a/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlEdgeFilters.cpp
+++ b/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlEdgeFilters.cpp
@@ -9,6 +9,7 @@
 #include "Containers/PCGExManagedObjects.h"
 #include "Core/PCGExClusterFilter.h"
 #include "Core/PCGExFillControlsFactoryProvider.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 bool FPCGExFillControlEdgeFilters::PrepareForDiffusions(FPCGExContext* InContext, const TSharedPtr<PCGExFloodFill::FFillControlsHandler>& InHandler)
 {
@@ -20,7 +21,7 @@ bool FPCGExFillControlEdgeFilters::PrepareForDiffusions(FPCGExContext* InContext
 	const UPCGExFillControlsFactoryEdgeFilters* TypedFactory = Cast<UPCGExFillControlsFactoryEdgeFilters>(Factory);
 
 	EdgeFilterManager = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), InHandler->VtxDataFacade.ToSharedRef(), InHandler->EdgeDataFacade.ToSharedRef());
-	EdgeFilterManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters);
+	EdgeFilterManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters());
 	EdgeFilterManager->bUseEdgeAsPrimary = true;
 
 	return EdgeFilterManager->Init(InContext, TypedFactory->FilterFactories);
@@ -74,7 +75,7 @@ UPCGExFactoryData* UPCGExFillControlsEdgeFiltersProviderSettings::CreateFactory(
 	PCGEX_FORWARD_FILLCONTROL_FACTORY
 	Super::CreateFactory(InContext, NewFactory);
 
-	if (!GetInputFactories(InContext, PCGExFilters::Labels::SourceEdgeFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterEdgeFilters))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceEdgeFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterEdgeFilters()))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;

--- a/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlHxBudget.cpp
+++ b/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlHxBudget.cpp
@@ -130,7 +130,7 @@ UPCGExFactoryData* UPCGExFillControlsHeuristicsBudgetProviderSettings::CreateFac
 	Super::CreateFactory(InContext, NewFactory);
 
 	// Heuristics are optional for budget - can use PathDistance if not provided
-	PCGExFactories::GetInputFactories(InContext, PCGExHeuristics::Labels::SourceHeuristicsLabel, NewFactory->HeuristicsFactories, {PCGExFactories::EType::Heuristics}, false);
+	PCGExFactories::GetInputFactories(InContext, PCGExHeuristics::Labels::SourceHeuristicsLabel, NewFactory->HeuristicsFactories, {FPCGExDataTypeInfoHeuristics::AsId()}, false);
 
 	return NewFactory;
 }

--- a/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlHxScoring.cpp
+++ b/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlHxScoring.cpp
@@ -114,7 +114,7 @@ UPCGExFactoryData* UPCGExFillControlsHeuristicsScoringProviderSettings::CreateFa
 	PCGEX_FORWARD_FILLCONTROL_FACTORY
 	Super::CreateFactory(InContext, NewFactory);
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExHeuristics::Labels::SourceHeuristicsLabel, NewFactory->HeuristicsFactories, {PCGExFactories::EType::Heuristics}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExHeuristics::Labels::SourceHeuristicsLabel, NewFactory->HeuristicsFactories, {FPCGExDataTypeInfoHeuristics::AsId()}))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;

--- a/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlHxThreshold.cpp
+++ b/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlHxThreshold.cpp
@@ -138,7 +138,7 @@ UPCGExFactoryData* UPCGExFillControlsHeuristicsThresholdProviderSettings::Create
 	PCGEX_FORWARD_FILLCONTROL_FACTORY
 	Super::CreateFactory(InContext, NewFactory);
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExHeuristics::Labels::SourceHeuristicsLabel, NewFactory->HeuristicsFactories, {PCGExFactories::EType::Heuristics}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExHeuristics::Labels::SourceHeuristicsLabel, NewFactory->HeuristicsFactories, {FPCGExDataTypeInfoHeuristics::AsId()}))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;

--- a/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlVtxFilters.cpp
+++ b/Source/PCGExElementsFloodFill/Private/FillControls/PCGExFillControlVtxFilters.cpp
@@ -8,6 +8,7 @@
 #include "Containers/PCGExManagedObjects.h"
 #include "Core/PCGExClusterFilter.h"
 #include "Core/PCGExFillControlsFactoryProvider.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 bool FPCGExFillControlVtxFilters::PrepareForDiffusions(FPCGExContext* InContext, const TSharedPtr<PCGExFloodFill::FFillControlsHandler>& InHandler)
 {
@@ -19,7 +20,7 @@ bool FPCGExFillControlVtxFilters::PrepareForDiffusions(FPCGExContext* InContext,
 	const UPCGExFillControlsFactoryVtxFilters* TypedFactory = Cast<UPCGExFillControlsFactoryVtxFilters>(Factory);
 
 	VtxFilterManager = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), InHandler->VtxDataFacade.ToSharedRef(), InHandler->EdgeDataFacade.ToSharedRef());
-	VtxFilterManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+	VtxFilterManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 	return VtxFilterManager->Init(InContext, TypedFactory->FilterFactories);
 }
 
@@ -108,7 +109,7 @@ UPCGExFactoryData* UPCGExFillControlsVtxFiltersProviderSettings::CreateFactory(F
 	PCGEX_FORWARD_FILLCONTROL_FACTORY
 	Super::CreateFactory(InContext, NewFactory);
 
-	if (!GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterNodeFilters))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceVtxFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterNodeFilters()))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;

--- a/Source/PCGExElementsFloodFill/Public/Core/PCGExFillControlsFactoryProvider.h
+++ b/Source/PCGExElementsFloodFill/Public/Core/PCGExFillControlsFactoryProvider.h
@@ -67,11 +67,6 @@ public:
 
 	FPCGExFillControlConfigBase ConfigBase;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FillControls;
-	}
-
 	virtual bool RegisterConsumableAttributesWithData(FPCGExContext* InContext, const UPCGData* InData) const override;
 
 	virtual TSharedPtr<FPCGExFillControlOperation> CreateOperation(FPCGExContext* InContext) const;

--- a/Source/PCGExElementsMeta/Private/Elements/PCGExBlendAttributes.cpp
+++ b/Source/PCGExElementsMeta/Private/Elements/PCGExBlendAttributes.cpp
@@ -37,7 +37,7 @@ bool FPCGExBlendAttributesElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(BlendAttributes)
 
-	return PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending});
+	return PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()});
 }
 
 bool FPCGExBlendAttributesElement::AdvanceWork(FPCGExContext* InContext, const UPCGExSettings* InSettings) const

--- a/Source/PCGExElementsMeta/Private/Elements/PCGExPromoteAttributes.cpp
+++ b/Source/PCGExElementsMeta/Private/Elements/PCGExPromoteAttributes.cpp
@@ -280,7 +280,7 @@ bool FPCGExAttributesToTagsElement::Boot(FPCGExContext* InContext) const
 	// Pickers are valid for every resolution -- including Self -- so load them before the Self short-circuit below.
 	if (Settings->Selection == EPCGExCollectionEntrySelection::Picker || Settings->Selection == EPCGExCollectionEntrySelection::PickerFirst || Settings->Selection == EPCGExCollectionEntrySelection::PickerLast)
 	{
-		if (!PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {PCGExFactories::EType::IndexPicker}))
+		if (!PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {FPCGExDataTypeInfoPicker::AsId()}))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsMeta/Private/Elements/PCGExWriteStates.cpp
+++ b/Source/PCGExElementsMeta/Private/Elements/PCGExWriteStates.cpp
@@ -33,7 +33,7 @@ bool FPCGExWriteStatesElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(WriteStates)
 
-	return PCGExFactories::GetInputFactories(Context, PCGExPointStates::Labels::SourceStatesLabel, Context->StateFactories, {PCGExFactories::EType::PointState});
+	return PCGExFactories::GetInputFactories(Context, PCGExPointStates::Labels::SourceStatesLabel, Context->StateFactories, {FPCGExDataTypeInfoPointState::AsId()});
 }
 
 bool FPCGExWriteStatesElement::AdvanceWork(FPCGExContext* InContext, const UPCGExSettings* InSettings) const

--- a/Source/PCGExElementsMeta/Private/Elements/Partition/PCGExModularPartitionByValues.cpp
+++ b/Source/PCGExElementsMeta/Private/Elements/Partition/PCGExModularPartitionByValues.cpp
@@ -38,7 +38,7 @@ TArray<FPCGPinProperties> UPCGExModularPartitionByValuesSettings::InputPinProper
 bool UPCGExModularPartitionByValuesSettings::GetPartitionRules(FPCGExContext* InContext, TArray<FPCGExPartitonRuleConfig>& OutRules) const
 {
 	TArray<TObjectPtr<const UPCGExPartitionRule>> Factories;
-	if (!PCGExFactories::GetInputFactories(InContext, TEXT("PartitionRules"), Factories, {PCGExFactories::EType::RulePartition}))
+	if (!PCGExFactories::GetInputFactories(InContext, TEXT("PartitionRules"), Factories, {FPCGExDataTypeInfoPartitionRule::AsId()}))
 	{
 		return false;
 	}

--- a/Source/PCGExElementsMeta/Public/Elements/PCGExAttributeStats.h
+++ b/Source/PCGExElementsMeta/Public/Elements/PCGExAttributeStats.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Utils/PCGExCompare.h"
 
 
@@ -58,7 +59,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Attributes to get. */

--- a/Source/PCGExElementsMeta/Public/Elements/PCGExBlendAttributes.h
+++ b/Source/PCGExElementsMeta/Public/Elements/PCGExBlendAttributes.h
@@ -7,6 +7,7 @@
 #include "PCGExFilterCommon.h"
 #include "Core/PCGExPointsProcessor.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "PCGExBlendAttributes.generated.h"
 
 class UPCGExBlendOpFactory;
@@ -37,7 +38,7 @@ public:
 	}
 #endif
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 protected:
 	virtual TArray<FPCGPinProperties> InputPinProperties() const override;

--- a/Source/PCGExElementsMeta/Public/Elements/PCGExRefreshSeed.h
+++ b/Source/PCGExElementsMeta/Public/Elements/PCGExRefreshSeed.h
@@ -7,6 +7,7 @@
 #include "PCGExFilterCommon.h"
 #include "Core/PCGExPointsProcessor.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "PCGExRefreshSeed.generated.h"
 
 /**
@@ -33,7 +34,7 @@ public:
 	}
 #endif
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 	virtual bool SupportsDataStealing() const override
 	{

--- a/Source/PCGExElementsMeta/Public/Elements/PCGExUberNoise.h
+++ b/Source/PCGExElementsMeta/Public/Elements/PCGExUberNoise.h
@@ -10,6 +10,7 @@
 #include "Details/PCGExAttributesDetails.h"
 #include "Details/PCGExInputShorthandsDetails.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "UObject/Object.h"
 #include "Utils/PCGExCurveLookup.h"
 
@@ -64,7 +65,7 @@ public:
 	}
 #endif
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 protected:
 	virtual FPCGElementPtr CreateElement() const override;

--- a/Source/PCGExElementsMeta/Public/Elements/Partition/PCGExModularPartitionByValues.h
+++ b/Source/PCGExElementsMeta/Public/Elements/Partition/PCGExModularPartitionByValues.h
@@ -28,11 +28,6 @@ class UPCGExPartitionRule : public UPCGExFactoryData
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoPartitionRule)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::RulePartition;
-	}
-
 	FPCGExPartitonRuleConfig Config;
 };
 

--- a/Source/PCGExElementsPaths/Private/Elements/PCGExAttributeRolling.cpp
+++ b/Source/PCGExElementsPaths/Private/Elements/PCGExAttributeRolling.cpp
@@ -4,6 +4,7 @@
 #include "Elements/PCGExAttributeRolling.h"
 
 #include "Core/PCGExBlendOpsManager.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
@@ -64,30 +65,30 @@ bool FPCGExAttributeRollingElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->RangeControl == EPCGExRollingRangeControl::StartStop)
 	{
-		if (!PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourceStartConditionLabel, Context->StartFilterFactories, PCGExFactories::PointFilters))
+		if (!PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourceStartConditionLabel, Context->StartFilterFactories, PCGExFactories::PointFilters()))
 		{
 			return false;
 		}
 
-		if (!PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourceStopConditionLabel, Context->StopFilterFactories, PCGExFactories::PointFilters))
+		if (!PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourceStopConditionLabel, Context->StopFilterFactories, PCGExFactories::PointFilters()))
 		{
 			return false;
 		}
 	}
 	else
 	{
-		PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourceToggleConditionLabel, Context->StartFilterFactories, PCGExFactories::PointFilters, false);
+		PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourceToggleConditionLabel, Context->StartFilterFactories, PCGExFactories::PointFilters(), false);
 	}
 
 	if (Settings->ValueControl == EPCGExRollingValueControl::Pin)
 	{
-		if (!PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourcePinConditionLabel, Context->PinFilterFactories, PCGExFactories::PointFilters))
+		if (!PCGExFactories::GetInputFactories<UPCGExPointFilterFactoryData>(Context, PCGExFilters::Labels::SourcePinConditionLabel, Context->PinFilterFactories, PCGExFactories::PointFilters()))
 		{
 			return false;
 		}
 	}
 
-	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 
 	return true;
 }

--- a/Source/PCGExElementsPaths/Private/Elements/PCGExBlendPath.cpp
+++ b/Source/PCGExElementsPaths/Private/Elements/PCGExBlendPath.cpp
@@ -46,7 +46,7 @@ bool FPCGExBlendPathElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(BlendPath)
 
-	if (!PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}))
+	if (!PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}))
 	{
 		return false;
 	}

--- a/Source/PCGExElementsPaths/Private/Elements/PCGExBoundsPathIntersection.cpp
+++ b/Source/PCGExElementsPaths/Private/Elements/PCGExBoundsPathIntersection.cpp
@@ -85,7 +85,7 @@ bool FPCGExBoundsPathIntersectionElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_BIND_INSTANCED_FACTORY(Blending, UPCGExSubPointsBlendInstancedFactory, PCGExBlending::Labels::SourceOverridesBlendingOps)
 
-	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 
 	Context->TargetsHandler = MakeShared<PCGExMatching::FTargetsHandler>();
 	Context->NumMaxTargets = Context->TargetsHandler->Init(Context, PCGExCommon::Labels::SourceBoundsLabel);

--- a/Source/PCGExElementsPaths/Private/Elements/PCGExPathCrossings.cpp
+++ b/Source/PCGExElementsPaths/Private/Elements/PCGExPathCrossings.cpp
@@ -5,6 +5,7 @@
 
 #include "PCGParamData.h"
 #include "Blenders/PCGExUnionBlender.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Core/PCGExUnionData.h"
 #include "Data/PCGExData.h"
@@ -74,9 +75,9 @@ bool FPCGExPathCrossingsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_BIND_INSTANCED_FACTORY(Blending, UPCGExSubPointsBlendInstancedFactory, PCGExBlending::Labels::SourceOverridesBlendingOps)
 
-	GetInputFactories(Context, PCGExPaths::Labels::SourceCanCutFilters, Context->CanCutFilterFactories, PCGExFactories::PointFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExPaths::Labels::SourceCanCutFilters, Context->CanCutFilterFactories, PCGExFactories::PointFilters(), false);
 
-	GetInputFactories(Context, PCGExPaths::Labels::SourceCanBeCutFilters, Context->CanBeCutFilterFactories, PCGExFactories::PointFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExPaths::Labels::SourceCanBeCutFilters, Context->CanBeCutFilterFactories, PCGExFactories::PointFilters(), false);
 
 	Context->CrossingBlending = Settings->CrossingBlending;
 

--- a/Source/PCGExElementsPaths/Private/Elements/PCGExSmooth.cpp
+++ b/Source/PCGExElementsPaths/Private/Elements/PCGExSmooth.cpp
@@ -72,7 +72,7 @@ bool FPCGExSmoothElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->BlendingInterface == EPCGExBlendingInterface::Individual)
 	{
-		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 	}
 
 	return true;

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExBevelPath.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExBevelPath.h
@@ -8,6 +8,7 @@
 #include "Details/PCGExSettingsMacros.h"
 #include "Details/PCGExSubdivisionDetails.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Math/PCGExMathMean.h"
 #include "Utils/PCGValueRange.h"
 
@@ -78,7 +79,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExBevelPath::SourceBevelFilters, "Filters used to know if a point should be Beveled", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExBevelPath::SourceBevelFilters, "Filters used to know if a point should be Beveled", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Type of Bevel operation */

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExBoundsPathIntersection.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExBoundsPathIntersection.h
@@ -7,6 +7,7 @@
 #include "Core/PCGExPathProcessor.h"
 
 #include "Core/PCGExPointsProcessor.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Details/PCGExBoxIntersectionDetails.h"
 #include "Details/PCGExMatchingDetails.h"
 #include "Math/OBB/PCGExOBBIntersections.h"
@@ -55,7 +56,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	//PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	//PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** If enabled, allows you to filter out which targets get sampled by which data */

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExFuseCollinear.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExFuseCollinear.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "Core/PCGExPathProcessor.h"
 #include "Core/PCGExPointsProcessor.h"
@@ -39,7 +40,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceKeepConditionLabel, "List of filters that are checked to know whether a point can be removed or must be kept.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceKeepConditionLabel, "List of filters that are checked to know whether a point can be removed or must be kept.", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExOffsetPath.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExOffsetPath.h
@@ -8,6 +8,7 @@
 #include "Core/PCGExPathProcessor.h"
 #include "Details/PCGExSettingsMacros.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Paths/PCGExPath.h"
 #include "Paths/PCGExPathsCommon.h"
 
@@ -59,7 +60,7 @@ protected:
 public:
 	virtual PCGExData::EIOInit GetMainDataInitializationPolicy() const override;
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters which points will be offset", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters which points will be offset", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Algorithm used to compute the offset direction at each point. */

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExOrient.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExOrient.h
@@ -8,6 +8,7 @@
 #include "Factories/PCGExFactories.h"
 
 #include "Core/PCGExPointsProcessor.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Math/PCGExMathAxis.h"
 
 #include "Orient/PCGExOrientOperation.h"
@@ -54,7 +55,7 @@ protected:
 public:
 	virtual PCGExData::EIOInit GetMainDataInitializationPolicy() const override;
 
-	PCGEX_NODE_POINT_FILTER(FName("Flip Conditions"), "Filters used to know whether an orientation should be flipped or not", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(FName("Flip Conditions"), "Filters used to know whether an orientation should be flipped or not", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointProcessorSettings
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable))

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExPathReduce.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExPathReduce.h
@@ -8,6 +8,7 @@
 #include "Core/PCGExPathProcessor.h"
 #include "Details/PCGExInputShorthandsDetails.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Helpers/PCGExPathSimplifier.h"
 
 #include "PCGExPathReduce.generated.h"
@@ -40,7 +41,7 @@ public:
 
 protected:
 	virtual FPCGElementPtr CreateElement() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filter which points are going to be preserved.", PCGExFactories::PointFilters, Mode == EPCGExPathReduceFilterMode::Anchor)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filter which points are going to be preserved.", PCGExFactories::PointFilters(), Mode == EPCGExPathReduceFilterMode::Anchor)
 	//~End UPCGSettings
 
 public:

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExPathShift.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExPathShift.h
@@ -7,6 +7,7 @@
 #include "Core/PCGExPathProcessor.h"
 #include "Details/PCGExBlendingDetails.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Math/PCGExMath.h"
 #include "Paths/PCGExPathsCommon.h"
 
@@ -66,7 +67,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(InputMode == EPCGExShiftPathMode::Filter ? PCGExPaths::Labels::SourceShiftFilters : NAME_None, "Filters used to find the shift starting point.", PCGExFactories::PointFilters, InputMode == EPCGExShiftPathMode::Filter)
+	PCGEX_NODE_POINT_FILTER(InputMode == EPCGExShiftPathMode::Filter ? PCGExPaths::Labels::SourceShiftFilters : NAME_None, "Filters used to find the shift starting point.", PCGExFactories::PointFilters(), InputMode == EPCGExShiftPathMode::Filter)
 	//~End UPCGExPointsProcessorSettings
 
 	/** What data is shifted (index, metadata, properties, etc.). */

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExPathShrink.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExPathShrink.h
@@ -7,6 +7,7 @@
 #include "PCGExFilterCommon.h"
 #include "Core/PCGExPathProcessor.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "PCGExPathShrink.generated.h"
 
@@ -109,7 +110,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceStopConditionLabel, "", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceStopConditionLabel, "", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Which endpoints to shrink (start, end, or both). */

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExPathSlide.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExPathSlide.h
@@ -8,6 +8,7 @@
 #include "Core/PCGExPathProcessor.h"
 #include "Details/PCGExSettingsMacros.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Math/PCGExMathMean.h"
 
 #include "PCGExPathSlide.generated.h"
@@ -47,7 +48,7 @@ public:
 
 protected:
 	virtual FPCGElementPtr CreateElement() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filter which points are processed by the slide maths.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filter which points are processed by the slide maths.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 	virtual PCGExData::EIOInit GetMainDataInitializationPolicy() const override;

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExPathSplineMeshSimple.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExPathSplineMeshSimple.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "Core/PCGExPathProcessor.h"
 #include "Data/Descriptors/PCGExComponentDescriptors.h"
@@ -65,7 +66,7 @@ protected:
 	virtual PCGExData::EIOInit GetMainDataInitializationPolicy() const override;
 
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 	/** How the asset gets selected */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable))

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExSmooth.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExSmooth.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "Core/PCGExPathProcessor.h"
 #include "Details/PCGExBlendingDetails.h"
@@ -54,7 +55,7 @@ public:
 	// End of UObject interface
 #endif
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get smoothed.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get smoothed.", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = Settings, meta=(PCG_Overridable))

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExSplitPath.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExSplitPath.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "Core/PCGExPathProcessor.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "Core/PCGExPointsProcessor.h"
 
@@ -64,7 +65,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExSplitPath::SourceSplitFilters, "Filters used to know if a point should be split", PCGExFactories::PointFilters, true)
+	PCGEX_NODE_POINT_FILTER(PCGExSplitPath::SourceSplitFilters, "Filters used to know if a point should be split", PCGExFactories::PointFilters(), true)
 	//~End UPCGExPointsProcessorSettings
 
 	/** If both split and remove are true, the selected behavior takes priority */

--- a/Source/PCGExElementsPaths/Public/Elements/PCGExSubdivide.h
+++ b/Source/PCGExElementsPaths/Public/Elements/PCGExSubdivide.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "Core/PCGExPathProcessor.h"
 #include "Details/PCGExSettingsMacros.h"
@@ -43,7 +44,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filter which segments will be subdivided.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filter which segments will be subdivided.", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Reference for computing the blending interpolation point point */

--- a/Source/PCGExElementsProbing/Private/Elements/PCGExConnectPoints.cpp
+++ b/Source/PCGExElementsProbing/Private/Elements/PCGExConnectPoints.cpp
@@ -4,6 +4,7 @@
 #include "Elements/PCGExConnectPoints.h"
 
 #include "Containers/PCGExScopedContainers.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Core/PCGExProbeFactoryProvider.h"
 #include "Core/PCGExProbeOperation.h"
@@ -49,13 +50,13 @@ bool FPCGExConnectPointsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(ConnectPoints)
 
-	if (!PCGExFactories::GetInputFactories<UPCGExProbeFactoryData>(Context, PCGExClusters::Labels::SourceProbesLabel, Context->ProbeFactories, {PCGExFactories::EType::Probe}))
+	if (!PCGExFactories::GetInputFactories<UPCGExProbeFactoryData>(Context, PCGExClusters::Labels::SourceProbesLabel, Context->ProbeFactories, {FPCGExDataTypeInfoProbe::AsId()}))
 	{
 		return false;
 	}
 
-	GetInputFactories(Context, PCGExClusters::Labels::SourceFilterGenerators, Context->GeneratorsFiltersFactories, PCGExFactories::PointFilters, false);
-	GetInputFactories(Context, PCGExClusters::Labels::SourceFilterConnectables, Context->ConnectablesFiltersFactories, PCGExFactories::PointFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceFilterGenerators, Context->GeneratorsFiltersFactories, PCGExFactories::PointFilters(), false);
+	PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceFilterConnectables, Context->ConnectablesFiltersFactories, PCGExFactories::PointFilters(), false);
 
 	Context->CWCoincidenceTolerance = FVector(Settings->CoincidenceTolerance);
 

--- a/Source/PCGExElementsProbing/Public/Core/PCGExProbeFactoryProvider.h
+++ b/Source/PCGExElementsProbing/Public/Core/PCGExProbeFactoryProvider.h
@@ -36,11 +36,6 @@ class PCGEXELEMENTSPROBING_API UPCGExProbeFactoryData : public UPCGExFactoryData
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoProbe)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Probe;
-	}
-
 	virtual TSharedPtr<FPCGExProbeOperation> CreateOperation(FPCGExContext* InContext) const;
 };
 

--- a/Source/PCGExElementsSampling/Private/Core/PCGExTexCommon.cpp
+++ b/Source/PCGExElementsSampling/Private/Core/PCGExTexCommon.cpp
@@ -29,7 +29,7 @@ namespace PCGExTexture
 
 	bool FLookup::BuildFrom(FPCGExContext* InContext, const FName InPin)
 	{
-		if (!PCGExFactories::GetInputFactories(InContext, InPin, Factories, {PCGExFactories::EType::TexParam}))
+		if (!PCGExFactories::GetInputFactories(InContext, InPin, Factories, {FPCGExDataTypeInfoTexParam::AsId()}))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExGetTextureData.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExGetTextureData.cpp
@@ -78,7 +78,7 @@ bool FPCGExGetTextureDataElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->SourceType == EPCGExGetTexturePathType::MaterialPath)
 	{
-		if (!PCGExFactories::GetInputFactories(InContext, PCGExTexture::SourceTexLabel, Context->TexParamsFactories, {PCGExFactories::EType::TexParam}))
+		if (!PCGExFactories::GetInputFactories(InContext, PCGExTexture::SourceTexLabel, Context->TexParamsFactories, {FPCGExDataTypeInfoTexParam::AsId()}))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExSampleInsidePath.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExSampleInsidePath.cpp
@@ -138,7 +138,7 @@ bool FPCGExSampleInsidePathElement::Boot(FPCGExContext* InContext) const
 		return false;
 	}
 
-	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 
 	Context->TargetsHandler = MakeShared<PCGExMatching::FTargetsHandler>();
 	Context->NumMaxTargets = Context->TargetsHandler->Init(Context, PCGExCommon::Labels::SourceTargetsLabel, [&](const TSharedPtr<PCGExData::FPointIO>& IO, const int32 Idx)-> FBox

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExSampleNearestBounds.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExSampleNearestBounds.cpp
@@ -116,7 +116,7 @@ bool FPCGExSampleNearestBoundsElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->BlendingInterface == EPCGExBlendingInterface::Individual)
 	{
-		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 	}
 
 	Context->TargetsHandler = MakeShared<PCGExMatching::FTargetsHandler>();

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExSampleNearestPath.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExSampleNearestPath.cpp
@@ -138,7 +138,7 @@ bool FPCGExSampleNearestPathElement::Boot(FPCGExContext* InContext) const
 	PCGEX_FWD(ApplySampling)
 	Context->ApplySampling.Init();
 
-	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+	PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 
 	Context->TargetsHandler = MakeShared<PCGExMatching::FTargetsHandler>();
 	Context->NumMaxTargets = Context->TargetsHandler->Init(Context, PCGExPaths::Labels::SourcePathsLabel, [&](const TSharedPtr<PCGExData::FPointIO>& IO, const int32 Idx)-> FBox

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExSampleNearestPoint.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExSampleNearestPoint.cpp
@@ -140,7 +140,7 @@ bool FPCGExSampleNearestPointElement::Boot(FPCGExContext* InContext) const
 
 	if (Settings->BlendingInterface == EPCGExBlendingInterface::Individual)
 	{
-		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {PCGExFactories::EType::Blending}, false);
+		PCGExFactories::GetInputFactories<UPCGExBlendOpFactory>(Context, PCGExBlending::Labels::SourceBlendingLabel, Context->BlendingFactories, {FPCGExDataTypeInfoBlendOp::AsId()}, false);
 	}
 
 	Context->TargetsHandler = MakeShared<PCGExMatching::FTargetsHandler>();

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExSampleSurfaceGuided.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExSampleSurfaceGuided.cpp
@@ -108,7 +108,7 @@ bool FPCGExSampleSurfaceGuidedElement::Boot(FPCGExContext* InContext) const
 	{
 		Context->bExtractTextureParams = true;
 
-		if (!PCGExFactories::GetInputFactories(InContext, PCGExTexture::SourceTexLabel, Context->TexParamsFactories, {PCGExFactories::EType::TexParam}))
+		if (!PCGExFactories::GetInputFactories(InContext, PCGExTexture::SourceTexLabel, Context->TexParamsFactories, {FPCGExDataTypeInfoTexParam::AsId()}))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsSampling/Private/Elements/PCGExSampleTexture.cpp
+++ b/Source/PCGExElementsSampling/Private/Elements/PCGExSampleTexture.cpp
@@ -46,7 +46,7 @@ bool FPCGExSampleTextureElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(SampleTexture)
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExTexture::SourceTexLabel, Context->TexParamsFactories, {PCGExFactories::EType::TexParam}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExTexture::SourceTexLabel, Context->TexParamsFactories, {FPCGExDataTypeInfoTexParam::AsId()}))
 	{
 		return false;
 	}

--- a/Source/PCGExElementsSampling/Public/Core/PCGExTexParamFactoryProvider.h
+++ b/Source/PCGExElementsSampling/Public/Core/PCGExTexParamFactoryProvider.h
@@ -131,11 +131,6 @@ class UPCGExTexParamFactoryData : public UPCGExFactoryData
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoTexParam)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::TexParam;
-	}
-
 	FPCGExTextureParamConfig Config;
 	FHashedMaterialParameterInfo Infos;
 };

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExDiscardByOverlap.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExDiscardByOverlap.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "PCGExOctree.h"
 #include "Core/PCGExPointsProcessor.h"
 #include "Data/PCGExPointElements.h"
@@ -134,7 +135,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filter which points can be considered for overlap.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filter which points can be considered for overlap.", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Overlap test mode */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExGetTextureData.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExGetTextureData.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 
 #include "Core/PCGExPointsProcessor.h"
@@ -72,7 +73,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Type of path */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestBounds.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestBounds.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Curves/CurveFloat.h"
 #include "Curves/RichCurve.h"
 #include "Factories/PCGExFactories.h"
@@ -111,7 +112,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** If enabled, allows you to filter out which targets get sampled by which data */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestPath.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestPath.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Factories/PCGExFactories.h"
 
 #include "Curves/CurveFloat.h"
@@ -117,7 +118,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** If enabled, allows you to filter out which targets get sampled by which data */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestPoint.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestPoint.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExBlendingCommon.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Curves/CurveFloat.h"
 #include "Curves/RichCurve.h"
 #include "Factories/PCGExFactories.h"
@@ -98,7 +99,7 @@ protected:
 	//~Begin UPCGExPointsProcessorSettings
 
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 	//~End UPCGExPointsProcessorSettings
 

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestSpline.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestSpline.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Curves/CurveFloat.h"
 #include "Curves/RichCurve.h"
 #include "UObject/Object.h"
@@ -150,7 +151,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Sample inputs.*/

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestSurface.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleNearestSurface.h
@@ -6,6 +6,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Factories/PCGExFactories.h"
 
 #include "Core/PCGExPointsProcessor.h"
@@ -73,7 +74,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Surface source */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleOverlapStats.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleOverlapStats.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "PCGExDiscardByOverlap.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointsProcessor.h"
 
 #include "Sampling/PCGExSamplingCommon.h"
@@ -55,7 +56,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters used to know whether a point should be considered for overlap or not.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters used to know whether a point should be considered for overlap or not.", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Overlap test mode */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleSockets.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleSockets.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointsProcessor.h"
 #include "Details/PCGExSocketOutputDetails.h"
 #include "Factories/PCGExFactories.h"
@@ -49,7 +50,7 @@ public:
 protected:
 	virtual FPCGElementPtr CreateElement() const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get processed.", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters which points get processed.", PCGExFactories::PointFilters(), false)
 	//~End UPCGSettings
 
 public:

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleSurfaceGuided.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleSurfaceGuided.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Components/PrimitiveComponent.h"
 #include "Materials/MaterialInterface.h"
 
@@ -100,7 +101,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Surface source */

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSampleTexture.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSampleTexture.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 #include "Core/PCGExPointsProcessor.h"
 #include "Core/PCGExTexCommon.h"
@@ -55,7 +56,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourcePointFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Settings|Tagging", meta=(PCG_Overridable))

--- a/Source/PCGExElementsSampling/Public/Elements/PCGExSelfPruning.h
+++ b/Source/PCGExElementsSampling/Public/Elements/PCGExSelfPruning.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointsProcessor.h"
 #include "Data/PCGExDataHelpers.h"
 #include "Details/PCGExSettingsMacros.h"
@@ -59,7 +60,7 @@ public:
 
 	virtual bool IsPinUsedByNodeExecution(const UPCGPin* InPin) const override;
 	virtual bool OutputPinsCanBeDeactivated() const override { return true; }
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters which points can be processed as overlapping", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters which points can be processed as overlapping", PCGExFactories::PointFilters(), false)
 
 protected:
 	virtual bool HasDynamicPins() const override;

--- a/Source/PCGExElementsShapes/Private/Core/PCGExShapeProcessor.cpp
+++ b/Source/PCGExElementsShapes/Private/Core/PCGExShapeProcessor.cpp
@@ -59,7 +59,7 @@ bool FPCGExShapeProcessorElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(ShapeProcessor)
 
-	if (!PCGExFactories::GetInputFactories(Context, PCGExShapes::Labels::SourceShapeBuildersLabel, Context->BuilderFactories, {PCGExFactories::EType::ShapeBuilder}))
+	if (!PCGExFactories::GetInputFactories(Context, PCGExShapes::Labels::SourceShapeBuildersLabel, Context->BuilderFactories, {FPCGExDataTypeInfoShape::AsId()}))
 	{
 		return false;
 	}

--- a/Source/PCGExElementsShapes/Public/Core/PCGExShapeBuilderFactoryProvider.h
+++ b/Source/PCGExElementsShapes/Public/Core/PCGExShapeBuilderFactoryProvider.h
@@ -41,11 +41,6 @@ class PCGEXELEMENTSSHAPES_API UPCGExShapeBuilderFactoryData : public UPCGExFacto
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoShape)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::ShapeBuilder;
-	}
-
 	virtual TSharedPtr<FPCGExShapeBuilderOperation> CreateOperation(FPCGExContext* InContext) const;
 };
 

--- a/Source/PCGExElementsTensors/Private/Core/PCGExTensorHandler.cpp
+++ b/Source/PCGExElementsTensors/Private/Core/PCGExTensorHandler.cpp
@@ -76,7 +76,7 @@ namespace PCGExTensor
 	bool FTensorsHandler::Init(FPCGExContext* InContext, const FName InPin, const TSharedPtr<PCGExData::FFacade>& InDataFacade)
 	{
 		TArray<TObjectPtr<const UPCGExTensorFactoryData>> InFactories;
-		if (!PCGExFactories::GetInputFactories(InContext, InPin, InFactories, {PCGExFactories::EType::Tensor}))
+		if (!PCGExFactories::GetInputFactories(InContext, InPin, InFactories, {FPCGExDataTypeInfoTensor::AsId()}))
 		{
 			return false;
 		}

--- a/Source/PCGExElementsTensors/Private/Elements/PCGExExtrudeTensors.cpp
+++ b/Source/PCGExElementsTensors/Private/Elements/PCGExExtrudeTensors.cpp
@@ -4,6 +4,7 @@
 #include "Elements/PCGExExtrudeTensors.h"
 
 #include "Containers/PCGExScopedContainers.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Core/PCGExTensorFactoryProvider.h"
 #include "Data/PCGExData.h"
@@ -126,12 +127,12 @@ bool FPCGExExtrudeTensorsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(ExtrudeTensors)
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, Context->TensorFactories, {PCGExFactories::EType::Tensor}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, Context->TensorFactories, {FPCGExDataTypeInfoTensor::AsId()}))
 	{
 		return false;
 	}
 
-	GetInputFactories(Context, PCGExFilters::Labels::SourceStopConditionLabel, Context->StopFilterFactories, PCGExFactories::PointFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExFilters::Labels::SourceStopConditionLabel, Context->StopFilterFactories, PCGExFactories::PointFilters(), false);
 	PCGExPointFilter::PruneForDirectEvaluation(Context, Context->StopFilterFactories);
 
 	if (Context->TensorFactories.IsEmpty())

--- a/Source/PCGExElementsTensors/Private/Elements/PCGExTensorsTransform.cpp
+++ b/Source/PCGExElementsTensors/Private/Elements/PCGExTensorsTransform.cpp
@@ -3,6 +3,7 @@
 
 #include "Elements/PCGExTensorsTransform.h"
 
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Core/PCGExTensorFactoryProvider.h"
 #include "Data/PCGExData.h"
@@ -37,7 +38,7 @@ bool FPCGExTensorsTransformElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(TensorsTransform)
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, Context->TensorFactories, {PCGExFactories::EType::Tensor}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, Context->TensorFactories, {FPCGExDataTypeInfoTensor::AsId()}))
 	{
 		return false;
 	}
@@ -50,7 +51,7 @@ bool FPCGExTensorsTransformElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_FOREACH_FIELD_TRTENSOR(PCGEX_OUTPUT_VALIDATE_NAME)
 
-	GetInputFactories(Context, PCGExFilters::Labels::SourceStopConditionLabel, Context->StopFilterFactories, PCGExFactories::PointFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExFilters::Labels::SourceStopConditionLabel, Context->StopFilterFactories, PCGExFactories::PointFilters(), false);
 
 	PCGExPointFilter::PruneForDirectEvaluation(Context, Context->StopFilterFactories);
 

--- a/Source/PCGExElementsTensors/Private/Filters/Points/PCGExTensorDotFilter.cpp
+++ b/Source/PCGExElementsTensors/Private/Filters/Points/PCGExTensorDotFilter.cpp
@@ -20,7 +20,7 @@ bool UPCGExTensorDotFilterFactory::Init(FPCGExContext* InContext)
 		return false;
 	}
 
-	return PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, TensorFactories, {PCGExFactories::EType::Tensor});
+	return PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, TensorFactories, {FPCGExDataTypeInfoTensor::AsId()});
 }
 
 TSharedPtr<PCGExPointFilter::IFilter> UPCGExTensorDotFilterFactory::CreateFilter() const

--- a/Source/PCGExElementsTensors/Private/Heuristics/PCGExHeuristicTensor.cpp
+++ b/Source/PCGExElementsTensors/Private/Heuristics/PCGExHeuristicTensor.cpp
@@ -60,7 +60,7 @@ PCGExFactories::EPreparationResult UPCGExHeuristicsFactoryTensor::Prepare(FPCGEx
 		return Result;
 	}
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, TensorFactories, {PCGExFactories::EType::Tensor}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, TensorFactories, {FPCGExDataTypeInfoTensor::AsId()}))
 	{
 		return PCGExFactories::EPreparationResult::Fail;
 	}

--- a/Source/PCGExElementsTensors/Private/Probes/PCGExProbeTensor.cpp
+++ b/Source/PCGExElementsTensors/Private/Probes/PCGExProbeTensor.cpp
@@ -26,7 +26,7 @@ PCGExFactories::EPreparationResult UPCGExProbeFactoryTensor::Prepare(FPCGExConte
 		return Result;
 	}
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, TensorFactories, {PCGExFactories::EType::Tensor}))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExTensor::SourceTensorsLabel, TensorFactories, {FPCGExDataTypeInfoTensor::AsId()}))
 	{
 		return PCGExFactories::EPreparationResult::Fail;
 	}

--- a/Source/PCGExElementsTensors/Public/Core/PCGExTensorFactoryProvider.h
+++ b/Source/PCGExElementsTensors/Public/Core/PCGExTensorFactoryProvider.h
@@ -52,11 +52,6 @@ class PCGEXELEMENTSTENSORS_API UPCGExTensorFactoryData : public UPCGExFactoryDat
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoTensor)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Tensor;
-	}
-
 	virtual TSharedPtr<PCGExTensorOperation> CreateOperation(FPCGExContext* InContext) const;
 
 	FPCGExTensorConfigBase BaseConfig;

--- a/Source/PCGExElementsTensors/Public/Elements/PCGExTensorsTransform.h
+++ b/Source/PCGExElementsTensors/Public/Elements/PCGExTensorsTransform.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "PCGExFilterCommon.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 
 #include "Core/PCGExPointsProcessor.h"
@@ -59,7 +60,7 @@ protected:
 
 	//~Begin UPCGExPointsProcessorSettings
 public:
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Whether to update point positions using tensor sampling. */

--- a/Source/PCGExElementsTopology/Private/Core/PCGExTopologyClustersProcessor.cpp
+++ b/Source/PCGExElementsTopology/Private/Core/PCGExTopologyClustersProcessor.cpp
@@ -12,6 +12,7 @@
 #include "Core/PCGExClusterMT.h"
 #include "Core/PCGExClustersProcessor.h"
 #include "Core/PCGExContext.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/PCGDynamicMeshData.h"
 #include "Data/PCGExData.h"
@@ -77,7 +78,7 @@ bool FPCGExTopologyClustersProcessorElement::Boot(FPCGExContext* InContext) cons
 		Context->Holes->EnsureProjected(); // Project once upfront
 	}
 
-	GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeConstrainsFiltersLabel, Context->EdgeConstraintsFilterFactories, PCGExFactories::ClusterEdgeFilters, false);
+	PCGExFactories::GetInputFactories(Context, PCGExClusters::Labels::SourceEdgeConstrainsFiltersLabel, Context->EdgeConstraintsFilterFactories, PCGExFactories::ClusterEdgeFilters(), false);
 
 	Context->HashMaps.Init(nullptr, Context->MainPoints->Num());
 	return true;

--- a/Source/PCGExFilters/Private/Core/PCGExClusterFilter.cpp
+++ b/Source/PCGExFilters/Private/Core/PCGExClusterFilter.cpp
@@ -3,6 +3,8 @@
 
 #include "Core/PCGExClusterFilter.h"
 
+#include "Core/PCGExFilterTypeSets.h"
+
 #include "Clusters/PCGExCluster.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
@@ -102,7 +104,7 @@ namespace PCGExClusterFilter
 	// receive edge data instead of vertex data.
 	bool FManager::InitFilter(FPCGExContext* InContext, const TSharedPtr<PCGExPointFilter::IFilter>& Filter)
 	{
-		if (PCGExFactories::SupportsClusterFilters.Contains(Filter->Factory->GetFactoryType()))
+		if (PCGExFactories::SupportsClusterFilters().Contains(Filter->Factory->GetDataTypeId()))
 		{
 			const TSharedPtr<IFilter> ClusterFilter = StaticCastSharedPtr<IFilter>(Filter);
 			return ClusterFilter->Init(InContext, Cluster, PointDataFacade, EdgeDataFacade);

--- a/Source/PCGExFilters/Private/Core/PCGExClusterStates.cpp
+++ b/Source/PCGExFilters/Private/Core/PCGExClusterStates.cpp
@@ -9,6 +9,7 @@
 #include "Clusters/PCGExCluster.h"
 #include "Containers/PCGExManagedObjects.h"
 #include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 PCG_DEFINE_TYPE_INFO(FPCGExDataTypeInfoClusterState, UPCGExClusterStateFactoryData)
 
@@ -53,7 +54,7 @@ namespace PCGExClusterStates
 		}
 
 		Manager = MakeShared<PCGExClusterFilter::FManager>(InCluster, PointDataFacade.ToSharedRef(), EdgeDataFacade.ToSharedRef());
-		Manager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+		Manager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 		return true;
 	}
 
@@ -176,7 +177,7 @@ UPCGExFactoryData* UPCGExClusterStateFactoryProviderSettings::CreateFactory(FPCG
 	return NewFactory;
 }
 
-TSet<PCGExFactories::EType> UPCGExClusterStateFactoryProviderSettings::GetInternalFilterTypes() const
+TSet<FPCGDataTypeBaseId> UPCGExClusterStateFactoryProviderSettings::GetInternalFilterTypes() const
 {
-	return PCGExFactories::ClusterNodeFilters;
+	return PCGExFactories::ClusterNodeFilters();
 }

--- a/Source/PCGExFilters/Private/Core/PCGExPointFilter.cpp
+++ b/Source/PCGExFilters/Private/Core/PCGExPointFilter.cpp
@@ -146,7 +146,7 @@ namespace PCGExPointFilter
 
 		for (const UPCGExPointFilterFactoryData* Factory : InFactories)
 		{
-			if (SupportedFactoriesTypes && !SupportedFactoriesTypes->Contains(Factory->GetFactoryType()))
+			if (SupportedFactoriesTypes && !SupportedFactoriesTypes->Contains(Factory->GetDataTypeId()))
 			{
 				PCGEX_LOG_INVALID_INPUT(InContext, FText::Format(FTEXT("A filter is of an unexpected type : {0}."), FText::FromString(GetNameSafe(Factory->GetClass()))))
 				continue;
@@ -451,12 +451,12 @@ namespace PCGExPointFilter
 		return NumPass;
 	}
 
-	void FManager::SetSupportedTypes(const TSet<PCGExFactories::EType>* InTypes)
+	void FManager::SetSupportedTypes(const TSet<FPCGDataTypeBaseId>* InTypes)
 	{
 		SupportedFactoriesTypes = InTypes;
 	}
 
-	const TSet<PCGExFactories::EType>* FManager::GetSupportedTypes() const
+	const TSet<FPCGDataTypeBaseId>* FManager::GetSupportedTypes() const
 	{
 		return SupportedFactoriesTypes;
 	}

--- a/Source/PCGExFilters/Private/Core/PCGExPointStates.cpp
+++ b/Source/PCGExFilters/Private/Core/PCGExPointStates.cpp
@@ -6,6 +6,7 @@
 
 #include "PCGParamData.h"
 #include "Containers/PCGExManagedObjects.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 PCG_DEFINE_TYPE_INFO(FPCGExDataTypeInfoPointState, UPCGExPointStateFactoryData)
 
@@ -139,7 +140,7 @@ UPCGExFactoryData* UPCGExStateFactoryProviderSettings::CreateFactory(FPCGExConte
 	NewFactory->Priority = Priority;
 
 	if (const bool bRequiresFilters = NewFactory->GetRequiresFilters();
-		!GetInputFactories(InContext, PCGExFilters::Labels::SourceFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterNodeFilters, bRequiresFilters) && bRequiresFilters)
+		!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceFiltersLabel, NewFactory->FilterFactories, PCGExFactories::ClusterNodeFilters(), bRequiresFilters) && bRequiresFilters)
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;
@@ -161,9 +162,9 @@ FString UPCGExStateFactoryProviderSettings::GetDisplayName() const
 }
 #endif
 
-TSet<PCGExFactories::EType> UPCGExStateFactoryProviderSettings::GetInternalFilterTypes() const
+TSet<FPCGDataTypeBaseId> UPCGExStateFactoryProviderSettings::GetInternalFilterTypes() const
 {
-	return PCGExFactories::PointFilters;
+	return PCGExFactories::PointFilters();
 }
 
 void UPCGExStateFactoryProviderSettings::OutputBitmasks(FPCGExContext* InContext, const FPCGExStateConfigBase& InConfig) const

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExBoundsFilter.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExBoundsFilter.cpp
@@ -27,7 +27,7 @@ bool UPCGExBoundsFilterFactory::Init(FPCGExContext* InContext)
 	}
 	if (Config.DataMatching.IsEnabled())
 	{
-		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {PCGExFactories::EType::MatchRule});
+		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {FPCGExDataTypeInfoMatchRule::AsId()});
 	}
 	return true;
 }

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExDistanceFilter.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExDistanceFilter.cpp
@@ -25,7 +25,7 @@ bool UPCGExDistanceFilterFactory::Init(FPCGExContext* InContext)
 	}
 	if (Config.DataMatching.IsEnabled())
 	{
-		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {PCGExFactories::EType::MatchRule});
+		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {FPCGExDataTypeInfoMatchRule::AsId()});
 	}
 	return true;
 }

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExFilterGroup.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExFilterGroup.cpp
@@ -7,6 +7,7 @@
 #include "PCGExFiltersSubSystem.h"
 #include "Clusters/PCGExCluster.h"
 #include "Containers/PCGExManagedObjects.h"
+#include "Core/PCGExFilterTypeSets.h"
 
 namespace PCGExFilterGroup
 {
@@ -37,7 +38,7 @@ namespace PCGExFilterGroup
 		*/
 	}
 
-	void FFilterGroup::SetSupportedTypes(const TSet<PCGExFactories::EType>* InTypes)
+	void FFilterGroup::SetSupportedTypes(const TSet<FPCGDataTypeBaseId>* InTypes)
 	{
 		SupportedFactoriesTypes = InTypes;
 	}
@@ -49,7 +50,7 @@ namespace PCGExFilterGroup
 
 		for (const UPCGExPointFilterFactoryData* ManagedFactory : *ManagedFactories)
 		{
-			if (SupportedFactoriesTypes && !SupportedFactoriesTypes->Contains(ManagedFactory->GetFactoryType()))
+			if (SupportedFactoriesTypes && !SupportedFactoriesTypes->Contains(ManagedFactory->GetDataTypeId()))
 			{
 				PCGEX_LOG_INVALID_INPUT(InContext, FText::Format(FTEXT("A grouped filter is of an unexpected type : {0}."), FText::FromString(GetNameSafe(ManagedFactory->GetClass()))));
 				continue;
@@ -135,7 +136,7 @@ namespace PCGExFilterGroup
 			return Filter->Init(InContext, PointDataFacade);
 		}
 
-		if (PCGExFactories::ClusterOnlyFilters.Contains(Filter->Factory->GetFactoryType()))
+		if (PCGExFactories::ClusterOnlyFilters().Contains(Filter->Factory->GetDataTypeId()))
 		{
 			if (!bInitForCluster)
 			{
@@ -431,7 +432,7 @@ UPCGExFactoryData* UPCGExFilterGroupProviderSettings::CreateFactory(FPCGExContex
 		NewFactory = InContext->ManagedObjects->New<UPCGExFilterGroupFactoryDataOR>();
 	}
 
-	if (!GetInputFactories(InContext, PCGExFilters::Labels::SourceFiltersLabel, NewFactory->FilterFactories, PCGExFactories::AnyFilters))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourceFiltersLabel, NewFactory->FilterFactories, PCGExFactories::AnyFilters()))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExNearestFilter.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExNearestFilter.cpp
@@ -26,7 +26,7 @@ bool UPCGExNearestFilterFactoryData::Init(FPCGExContext* InContext)
 	check(NearestConfig);
 	if (NearestConfig->DataMatching.IsEnabled())
 	{
-		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {PCGExFactories::EType::MatchRule});
+		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {FPCGExDataTypeInfoMatchRule::AsId()});
 	}
 	return true;
 }

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExNearestPointCheckFilter.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExNearestPointCheckFilter.cpp
@@ -9,6 +9,7 @@
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
 #include "Factories/PCGExFactories.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "PCGExMatching/Public/Helpers/PCGExMatchingHelpers.h"
 #include "PCGExMatching/Public/Helpers/PCGExTargetsHandler.h"
 
@@ -45,7 +46,7 @@ bool UPCGExNearestPointCheckFilterFactory::BuildTargetCaches(FPCGExContext* InCo
 	{
 		// Always add (even on failure) so the array stays index-aligned with the target's IO.
 		TSharedPtr<PCGExPointFilter::FManager> Manager = MakeShared<PCGExPointFilter::FManager>(Target);
-		Manager->SetSupportedTypes(&PCGExFactories::PointFilters);
+		Manager->SetSupportedTypes(&PCGExFactories::PointFilters());
 
 		const bool bManagerOk = Manager->Init(InContext, FilterFactories);
 		TargetFilterManagers->Add(bManagerOk ? Manager : nullptr);
@@ -185,7 +186,7 @@ UPCGExFactoryData* UPCGExNearestPointCheckFilterProviderSettings::CreateFactory(
 
 	Super::CreateFactory(InContext, NewFactory);
 
-	if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourcePointFiltersLabel, NewFactory->FilterFactories, PCGExFactories::PointFilters))
+	if (!PCGExFactories::GetInputFactories(InContext, PCGExFilters::Labels::SourcePointFiltersLabel, NewFactory->FilterFactories, PCGExFactories::PointFilters()))
 	{
 		InContext->ManagedObjects->Destroy(NewFactory);
 		return nullptr;

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExPickerFilter.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExPickerFilter.cpp
@@ -18,7 +18,7 @@ bool UPCGExPickerFilterFactory::Init(FPCGExContext* InContext)
 		return false;
 	}
 
-	return PCGExFactories::GetInputFactories(InContext, PCGExPickers::Labels::SourcePickersLabel, PickerFactories, {PCGExFactories::EType::IndexPicker});
+	return PCGExFactories::GetInputFactories(InContext, PCGExPickers::Labels::SourcePickersLabel, PickerFactories, {FPCGExDataTypeInfoPicker::AsId()});
 }
 
 TSharedPtr<PCGExPointFilter::IFilter> UPCGExPickerFilterFactory::CreateFilter() const

--- a/Source/PCGExFilters/Private/Filters/Points/PCGExPolyPathFilterFactory.cpp
+++ b/Source/PCGExFilters/Private/Filters/Points/PCGExPolyPathFilterFactory.cpp
@@ -66,7 +66,7 @@ PCGExFactories::EPreparationResult UPCGExPolyPathFilterFactory::Prepare(FPCGExCo
 	// They are consumed later (when filter instances are created), which always happens after Prepare().
 	if (DataMatching.IsEnabled())
 	{
-		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {PCGExFactories::EType::MatchRule});
+		PCGExFactories::GetInputFactories(InContext, PCGExMatching::Labels::SourceMatchRulesLabel, MatchRuleFactories, {FPCGExDataTypeInfoMatchRule::AsId()});
 	}
 
 	PCGEX_ASYNC_GROUP_CHKD_RET(TaskManager, CreatePolyPaths, PCGExFactories::EPreparationResult::Fail)

--- a/Source/PCGExFilters/Public/Core/PCGExClusterFilter.h
+++ b/Source/PCGExFilters/Public/Core/PCGExClusterFilter.h
@@ -88,11 +88,6 @@ class PCGEXFILTERS_API UPCGExNodeFilterFactoryData : public UPCGExClusterFilterF
 
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoFilterVtx)
-
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterNode;
-	}
 };
 
 UCLASS(Abstract)
@@ -128,11 +123,6 @@ class PCGEXFILTERS_API UPCGExEdgeFilterFactoryData : public UPCGExClusterFilterF
 
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoFilterEdge)
-
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterEdge;
-	}
 };
 
 UCLASS(Abstract)

--- a/Source/PCGExFilters/Public/Core/PCGExClusterStates.h
+++ b/Source/PCGExFilters/Public/Core/PCGExClusterStates.h
@@ -44,11 +44,6 @@ public:
 	UPROPERTY()
 	FPCGExClusterStateConfigBase Config;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::ClusterState;
-	}
-
 	virtual TSharedPtr<PCGExPointFilter::IFilter> CreateFilter() const override;
 
 	virtual void BeginDestroy() override;
@@ -132,5 +127,5 @@ public:
 	FPCGExClusterStateConfigBase Config;
 
 protected:
-	virtual TSet<PCGExFactories::EType> GetInternalFilterTypes() const override;
+	virtual TSet<FPCGDataTypeBaseId> GetInternalFilterTypes() const override;
 };

--- a/Source/PCGExFilters/Public/Core/PCGExFilterTypeSets.h
+++ b/Source/PCGExFilters/Public/Core/PCGExFilterTypeSets.h
@@ -1,0 +1,108 @@
+// Copyright 2026 Timothé Lapetite and contributors
+// Released under the MIT license https://opensource.org/license/MIT/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Data/Registry/PCGDataType.h"
+
+#include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExClusterStates.h"
+
+// Acceptance sets used to filter incoming factories on a pin (replaces the legacy
+// PCGExFactories::EType sets). They live here, in PCGExFilters, because they reference
+// FPCGDataTypeInfo structs that belong to this module and are invisible to PCGExCore.
+//
+// Membership is FLAT/EXACT: a factory is accepted when its GetDataTypeId() is contained
+// in the set. We intentionally do NOT use FPCGDataTypeIdentifier compositions here -
+// those auto-reduce a parent + child down to the parent, which would silently widen the
+// "point but not its cluster sub-filters" sets into "any filter". A plain TSet of base
+// ids preserves the legacy semantics exactly.
+//
+// Accessors are lazy (function-local statics) so they are built on first use, after the
+// reflection system is up - never during cross-module static initialization.
+
+namespace PCGExFactories
+{
+	// All filter kinds (point, vtx/node, edge, group, collection).
+	inline const TSet<FPCGDataTypeBaseId>& AnyFilters()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoFilterPoint::AsId(),
+			FPCGExDataTypeInfoFilterVtx::AsId(),
+			FPCGExDataTypeInfoFilterEdge::AsId(),
+			FPCGExDataTypeInfoFilter::AsId(), // filter group reports the base Filter id
+			FPCGExDataTypeInfoFilterCollection::AsId()
+		};
+		return Set;
+	}
+
+	// Point-context filters: point, group, collection - NOT cluster vtx/edge.
+	inline const TSet<FPCGDataTypeBaseId>& PointFilters()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoFilterPoint::AsId(),
+			FPCGExDataTypeInfoFilter::AsId(),
+			FPCGExDataTypeInfoFilterCollection::AsId()
+		};
+		return Set;
+	}
+
+	// Cluster node (vtx) context: point, vtx, group, collection - NOT edge.
+	inline const TSet<FPCGDataTypeBaseId>& ClusterNodeFilters()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoFilterPoint::AsId(),
+			FPCGExDataTypeInfoFilterVtx::AsId(),
+			FPCGExDataTypeInfoFilter::AsId(),
+			FPCGExDataTypeInfoFilterCollection::AsId()
+		};
+		return Set;
+	}
+
+	// Cluster edge context: point, edge, group, collection - NOT vtx.
+	inline const TSet<FPCGDataTypeBaseId>& ClusterEdgeFilters()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoFilterPoint::AsId(),
+			FPCGExDataTypeInfoFilterEdge::AsId(),
+			FPCGExDataTypeInfoFilter::AsId(),
+			FPCGExDataTypeInfoFilterCollection::AsId()
+		};
+		return Set;
+	}
+
+	// Filters that operate on cluster data (vtx, edge, cluster state) plus group & collection.
+	inline const TSet<FPCGDataTypeBaseId>& SupportsClusterFilters()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoFilterEdge::AsId(),
+			FPCGExDataTypeInfoFilterVtx::AsId(),
+			FPCGExDataTypeInfoClusterState::AsId(),
+			FPCGExDataTypeInfoFilter::AsId(),
+			FPCGExDataTypeInfoFilterCollection::AsId()
+		};
+		return Set;
+	}
+
+	// Cluster-only filters: vtx, edge, cluster state.
+	inline const TSet<FPCGDataTypeBaseId>& ClusterOnlyFilters()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoFilterEdge::AsId(),
+			FPCGExDataTypeInfoFilterVtx::AsId(),
+			FPCGExDataTypeInfoClusterState::AsId()
+		};
+		return Set;
+	}
+
+	// State factories (point + cluster).
+	inline const TSet<FPCGDataTypeBaseId>& ClusterStates()
+	{
+		static const TSet<FPCGDataTypeBaseId> Set = {
+			FPCGExDataTypeInfoClusterState::AsId(),
+			FPCGExDataTypeInfoPointState::AsId()
+		};
+		return Set;
+	}
+}

--- a/Source/PCGExFilters/Public/Core/PCGExPointFilter.h
+++ b/Source/PCGExFilters/Public/Core/PCGExPointFilter.h
@@ -75,11 +75,6 @@ class PCGEXFILTERS_API UPCGExFilterFactoryData : public UPCGExFactoryData
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoFilter)
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Filter;
-	}
-
 	virtual bool DomainCheck();
 
 	virtual bool GetOnlyUseDataDomain() const
@@ -122,11 +117,6 @@ class PCGEXFILTERS_API UPCGExPointFilterFactoryData : public UPCGExFilterFactory
 
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoFilterPoint)
-
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterPoint;
-	}
 };
 
 namespace PCGExPointFilter
@@ -187,7 +177,7 @@ namespace PCGExPointFilter
 		// Init() side effects. Apply the data-missing fallback locally (see PCGEX_QUIET_HANDLING_RET).
 		virtual bool Test(const TSharedPtr<PCGExData::FPointIO>& IO, const TSharedPtr<PCGExData::FPointIOCollection>& ParentCollection) const;
 
-		virtual void SetSupportedTypes(const TSet<PCGExFactories::EType>* InTypes)
+		virtual void SetSupportedTypes(const TSet<FPCGDataTypeBaseId>* InTypes)
 		{
 		}
 
@@ -297,11 +287,11 @@ namespace PCGExPointFilter
 		{
 		}
 
-		void SetSupportedTypes(const TSet<PCGExFactories::EType>* InTypes);
-		const TSet<PCGExFactories::EType>* GetSupportedTypes() const;
+		void SetSupportedTypes(const TSet<FPCGDataTypeBaseId>* InTypes);
+		const TSet<FPCGDataTypeBaseId>* GetSupportedTypes() const;
 
 	protected:
-		const TSet<PCGExFactories::EType>* SupportedFactoriesTypes = nullptr;
+		const TSet<FPCGDataTypeBaseId>* SupportedFactoriesTypes = nullptr;
 		TArray<TSharedPtr<IFilter>> ManagedFilters; // Owns the filter instances
 		TArray<const IFilter*> Stack;               // Raw pointers for cache-friendly iteration in Test()
 
@@ -345,11 +335,6 @@ class PCGEXFILTERS_API UPCGExFilterCollectionFactoryData : public UPCGExPointFil
 
 public:
 	PCG_ASSIGN_TYPE_INFO(FPCGExDataTypeInfoFilterCollection)
-
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterCollection;
-	}
 
 	virtual bool DomainCheck() override;
 	virtual bool SupportsCollectionEvaluation() const override;

--- a/Source/PCGExFilters/Public/Core/PCGExPointStates.h
+++ b/Source/PCGExFilters/Public/Core/PCGExPointStates.h
@@ -88,11 +88,6 @@ public:
 		return true;
 	}
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::PointState;
-	}
-
 	virtual TSharedPtr<PCGExPointFilter::IFilter> CreateFilter() const override;
 
 	virtual void RegisterBuffersDependencies(FPCGExContext* InContext, PCGExData::FFacadePreloader& FacadePreloader) const override;
@@ -207,6 +202,6 @@ public:
 #endif
 
 protected:
-	virtual TSet<PCGExFactories::EType> GetInternalFilterTypes() const;
+	virtual TSet<FPCGDataTypeBaseId> GetInternalFilterTypes() const;
 	virtual void OutputBitmasks(FPCGExContext* InContext, const FPCGExStateConfigBase& InConfig) const;
 };

--- a/Source/PCGExFilters/Public/Filters/Points/PCGExFilterGroup.h
+++ b/Source/PCGExFilters/Public/Filters/Points/PCGExFilterGroup.h
@@ -32,11 +32,6 @@ public:
 	virtual bool SupportsProxyEvaluation() const override;
 	virtual bool SupportsCollectionEvaluation() const override;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterGroup;
-	}
-
 	virtual TSharedPtr<PCGExPointFilter::IFilter> CreateFilter() const override
 	{
 		return nullptr;
@@ -55,11 +50,6 @@ class UPCGExFilterGroupFactoryDataAND : public UPCGExFilterGroupFactoryData
 	GENERATED_BODY()
 
 public:
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterGroup;
-	}
-
 	virtual TSharedPtr<PCGExPointFilter::IFilter> CreateFilter() const override;
 };
 
@@ -70,11 +60,6 @@ class UPCGExFilterGroupFactoryDataOR : public UPCGExFilterGroupFactoryData
 	GENERATED_BODY()
 
 public:
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::FilterGroup;
-	}
-
 	virtual TSharedPtr<PCGExPointFilter::IFilter> CreateFilter() const override;
 };
 
@@ -120,10 +105,10 @@ namespace PCGExFilterGroup
 		virtual bool Test(const PCGExGraphs::FEdge& Edge) const override = 0;
 		virtual bool Test(const TSharedPtr<PCGExData::FPointIO>& IO, const TSharedPtr<PCGExData::FPointIOCollection>& ParentCollection) const override = 0;
 
-		virtual void SetSupportedTypes(const TSet<PCGExFactories::EType>* InTypes) override;
+		virtual void SetSupportedTypes(const TSet<FPCGDataTypeBaseId>* InTypes) override;
 
 	protected:
-		const TSet<PCGExFactories::EType>* SupportedFactoriesTypes = nullptr;
+		const TSet<FPCGDataTypeBaseId>* SupportedFactoriesTypes = nullptr;
 		TArray<TSharedPtr<PCGExPointFilter::IFilter>> ManagedFilters;
 		TArray<const PCGExPointFilter::IFilter*> Stack;
 

--- a/Source/PCGExFoundations/Private/Core/PCGExPointsProcessor.cpp
+++ b/Source/PCGExFoundations/Private/Core/PCGExPointsProcessor.cpp
@@ -106,9 +106,9 @@ PCGExData::EIOInit UPCGExPointsProcessorSettings::GetMainOutputInitMode() const
 	return PCGExData::EIOInit::NoInit;
 }
 
-TSet<PCGExFactories::EType> UPCGExPointsProcessorSettings::GetPointFilterTypes() const
+TSet<FPCGDataTypeBaseId> UPCGExPointsProcessorSettings::GetPointFilterTypes() const
 {
-	return PCGExFactories::PointFilters;
+	return PCGExFactories::PointFilters();
 }
 
 FPCGExPointsProcessorContext::~FPCGExPointsProcessorContext()
@@ -344,7 +344,7 @@ bool FPCGExPointsProcessorElement::Boot(FPCGExContext* InContext) const
 	if (Settings->SupportsPointFilters())
 	{
 		if (const bool bRequiredFilters = Settings->RequiresPointFilters();
-			!GetInputFactories(Context, Settings->GetPointFilterPin(), Context->FilterFactories, Settings->GetPointFilterTypes(), bRequiredFilters) && bRequiredFilters)
+			!PCGExFactories::GetInputFactories(Context, Settings->GetPointFilterPin(), Context->FilterFactories, Settings->GetPointFilterTypes(), bRequiredFilters) && bRequiredFilters)
 		{
 			return false;
 		}

--- a/Source/PCGExFoundations/Private/Elements/ControlFlow/PCGExRecursionTracker.cpp
+++ b/Source/PCGExFoundations/Private/Elements/ControlFlow/PCGExRecursionTracker.cpp
@@ -3,7 +3,7 @@
 
 #include "Elements/ControlFlow/PCGExRecursionTracker.h"
 
-
+#include "Core/PCGExFilterTypeSets.h"
 #include "PCGGraph.h"
 #include "PCGParamData.h"
 #include "PCGPin.h"
@@ -170,7 +170,7 @@ bool FPCGExRecursionTrackerElement::AdvanceWork(FPCGExContext* InContext, const 
 		// Initialize collection filters if we have some inputs
 		TArray<TObjectPtr<const UPCGExPointFilterFactoryData>> FilterFactories;
 
-		if (PCGExFactories::GetInputFactories(Context, PCGExRecursionTracker::SourceTrackerFilters, FilterFactories, PCGExFactories::PointFilters, false))
+		if (PCGExFactories::GetInputFactories(Context, PCGExRecursionTracker::SourceTrackerFilters, FilterFactories, PCGExFactories::PointFilters(), false))
 		{
 			PCGEX_MAKE_SHARED(DummyFacade, PCGExData::FFacade, TrackersCollection->Pairs[0].ToSharedRef())
 			CollectionFilters = MakeShared<PCGExPointFilter::FManager>(DummyFacade.ToSharedRef());
@@ -352,7 +352,7 @@ Context->StageOutput(Extra, PCGExRecursionTracker::Output##_NAME##Label, PCGExDa
 					TSharedPtr<PCGExPointFilter::FManager> TestDataFilters = nullptr;
 					TArray<TObjectPtr<const UPCGExPointFilterFactoryData>> TestFilterFactories;
 
-					if (!bShouldStop && PCGExFactories::GetInputFactories(Context, PCGExRecursionTracker::SourceTrackerFilters, TestFilterFactories, PCGExFactories::PointFilters, false))
+					if (!bShouldStop && PCGExFactories::GetInputFactories(Context, PCGExRecursionTracker::SourceTrackerFilters, TestFilterFactories, PCGExFactories::PointFilters(), false))
 					{
 						PCGEX_MAKE_SHARED(DummyFacade, PCGExData::FFacade, TestDataCollection->Pairs[0].ToSharedRef())
 						TestDataFilters = MakeShared<PCGExPointFilter::FManager>(DummyFacade.ToSharedRef());

--- a/Source/PCGExFoundations/Private/Elements/ControlFlow/PCGExUberBranch.cpp
+++ b/Source/PCGExFoundations/Private/Elements/ControlFlow/PCGExUberBranch.cpp
@@ -3,6 +3,7 @@
 
 #include "Elements/ControlFlow/PCGExUberBranch.h"
 
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
@@ -88,7 +89,7 @@ bool FPCGExUberBranchElement::Boot(FPCGExContext* InContext) const
 		bool bInitialized = false;
 
 		if (TArray<TObjectPtr<const UPCGExPointFilterFactoryData>> Factories;
-			GetInputFactories(Context, Settings->InputLabels[i], Factories, PCGExFactories::PointFilters))
+			PCGExFactories::GetInputFactories(Context, Settings->InputLabels[i], Factories, PCGExFactories::PointFilters()))
 		{
 			for (const TSharedPtr<PCGExData::FFacade>& Facade : Context->Facades)
 			{

--- a/Source/PCGExFoundations/Private/Elements/Filtering/PCGExCherryPickPoints.cpp
+++ b/Source/PCGExFoundations/Private/Elements/Filtering/PCGExCherryPickPoints.cpp
@@ -41,7 +41,7 @@ bool FPCGExCherryPickPointsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(CherryPickPoints)
 
-	return PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {PCGExFactories::EType::IndexPicker});
+	return PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {FPCGExDataTypeInfoPicker::AsId()});
 }
 
 bool FPCGExCherryPickPointsElement::AdvanceWork(FPCGExContext* InContext, const UPCGExSettings* InSettings) const

--- a/Source/PCGExFoundations/Private/Elements/Filtering/PCGExUberFilter.cpp
+++ b/Source/PCGExFoundations/Private/Elements/Filtering/PCGExUberFilter.cpp
@@ -103,7 +103,7 @@ bool FPCGExUberFilterElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(UberFilter)
 
-	PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {PCGExFactories::EType::IndexPicker}, false);
+	PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {FPCGExDataTypeInfoPicker::AsId()}, false);
 
 	if (Settings->Mode == EPCGExUberFilterMode::Write)
 	{

--- a/Source/PCGExFoundations/Private/Elements/Filtering/PCGExUberFilterCascade.cpp
+++ b/Source/PCGExFoundations/Private/Elements/Filtering/PCGExUberFilterCascade.cpp
@@ -4,6 +4,7 @@
 #include "Elements/Filtering/PCGExUberFilterCascade.h"
 
 #include "Containers/PCGExScopedContainers.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointFilter.h"
 #include "Data/PCGExData.h"
 #include "Data/PCGExPointIO.h"
@@ -101,7 +102,7 @@ bool FPCGExUberFilterCascadeElement::Boot(FPCGExContext* InContext) const
 
 	for (int i = 0; i < Settings->NumBranches; i++)
 	{
-		GetInputFactories(Context, Settings->InputLabels[i], Context->BranchFilterFactories[i], PCGExFactories::PointFilters, false);
+		PCGExFactories::GetInputFactories(Context, Settings->InputLabels[i], Context->BranchFilterFactories[i], PCGExFactories::PointFilters(), false);
 	}
 
 	Context->BranchOutputs.SetNum(Settings->NumBranches);

--- a/Source/PCGExFoundations/Private/Elements/Filtering/PCGExUberFilterCollections.cpp
+++ b/Source/PCGExFoundations/Private/Elements/Filtering/PCGExUberFilterCollections.cpp
@@ -67,7 +67,7 @@ bool FPCGExUberFilterCollectionsElement::Boot(FPCGExContext* InContext) const
 
 	PCGEX_CONTEXT_AND_SETTINGS(UberFilterCollections)
 
-	PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {PCGExFactories::EType::IndexPicker}, false);
+	PCGExFactories::GetInputFactories(Context, PCGExPickers::Labels::SourcePickersLabel, Context->PickerFactories, {FPCGExDataTypeInfoPicker::AsId()}, false);
 
 	Context->Inside = MakeShared<PCGExData::FPointIOCollection>(Context, true);
 	Context->Outside = MakeShared<PCGExData::FPointIOCollection>(Context, true);

--- a/Source/PCGExFoundations/Public/Core/PCGExPointsProcessor.h
+++ b/Source/PCGExFoundations/Public/Core/PCGExPointsProcessor.h
@@ -14,6 +14,7 @@
 #include "Core/PCGExContext.h"
 #include "Core/PCGExElement.h"
 #include "Core/PCGExSettings.h"
+#include "Core/PCGExFilterTypeSets.h" // Factory acceptance sets used by PCGEX_NODE_POINT_FILTER
 
 #include "PCGExPointsProcessor.generated.h"
 
@@ -128,7 +129,7 @@ public:
 		return TEXT("Filters");
 	}
 
-	virtual TSet<PCGExFactories::EType> GetPointFilterTypes() const;
+	virtual TSet<FPCGDataTypeBaseId> GetPointFilterTypes() const;
 
 	virtual bool RequiresPointFilters() const
 	{

--- a/Source/PCGExFoundations/Public/Elements/Filtering/PCGExUberFilter.h
+++ b/Source/PCGExFoundations/Public/Elements/Filtering/PCGExUberFilter.h
@@ -80,7 +80,7 @@ public:
 	virtual PCGExData::EIOInit GetMainDataInitializationPolicy() const override;
 
 	virtual FName GetMainOutputPin() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, true)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), true)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Write result to point instead of split outputs */

--- a/Source/PCGExFoundations/Public/Elements/Filtering/PCGExUberFilterCollections.h
+++ b/Source/PCGExFoundations/Public/Elements/Filtering/PCGExUberFilterCollections.h
@@ -61,7 +61,7 @@ protected:
 public:
 	virtual FName GetMainOutputPin() const override;
 	virtual bool GetIsMainTransactional() const override;
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, true)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), true)
 	//~End UPCGExPointsProcessorSettings
 
 	/** Write result to point instead of split outputs */

--- a/Source/PCGExFoundations/Public/Elements/PCGExCopyToPoints.h
+++ b/Source/PCGExFoundations/Public/Elements/PCGExCopyToPoints.h
@@ -39,7 +39,7 @@ public:
 		return PCGEX_NODE_COLOR_OPTIN_NAME(MiscWrite);
 	}
 
-	//PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, true)
+	//PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), true)
 #endif
 
 protected:

--- a/Source/PCGExFoundations/Public/Elements/PCGExTransformPoints.h
+++ b/Source/PCGExFoundations/Public/Elements/PCGExTransformPoints.h
@@ -39,7 +39,7 @@ public:
 	}
 #endif
 
-	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters, false)
+	PCGEX_NODE_POINT_FILTER(PCGExFilters::Labels::SourceFiltersLabel, "Filters", PCGExFactories::PointFilters(), false)
 
 protected:
 	virtual FPCGElementPtr CreateElement() const override;

--- a/Source/PCGExGraphs/Private/Core/PCGExClusterMT.cpp
+++ b/Source/PCGExGraphs/Private/Core/PCGExClusterMT.cpp
@@ -10,6 +10,7 @@
 #include "Clusters/PCGExClustersHelpers.h"
 #include "Clusters/Artifacts/PCGExCachedFaceEnumerator.h"
 #include "Core/PCGExClusterFilter.h"
+#include "Core/PCGExFilterTypeSets.h"
 #include "Core/PCGExPointsMT.h"
 #include "Data/PCGExClusterData.h"
 #include "Data/PCGExData.h"
@@ -535,7 +536,7 @@ namespace PCGExClusterMT
 		}
 
 		VtxFiltersManager = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), VtxDataFacade, EdgeDataFacade);
-		VtxFiltersManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters);
+		VtxFiltersManager->SetSupportedTypes(&PCGExFactories::ClusterNodeFilters());
 		return VtxFiltersManager->Init(ExecutionContext, *InFilterFactories);
 	}
 
@@ -564,7 +565,7 @@ namespace PCGExClusterMT
 
 		EdgesFiltersManager = MakeShared<PCGExClusterFilter::FManager>(Cluster.ToSharedRef(), VtxDataFacade, EdgeDataFacade);
 		EdgesFiltersManager->bUseEdgeAsPrimary = true;
-		EdgesFiltersManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters);
+		EdgesFiltersManager->SetSupportedTypes(&PCGExFactories::ClusterEdgeFilters());
 		return EdgesFiltersManager->Init(ExecutionContext, *InFilterFactories);
 	}
 

--- a/Source/PCGExGraphs/Private/Core/PCGExClustersProcessor.cpp
+++ b/Source/PCGExGraphs/Private/Core/PCGExClustersProcessor.cpp
@@ -478,7 +478,7 @@ bool FPCGExClustersProcessorElement::Boot(FPCGExContext* InContext) const
 
 	Context->bQuietMissingClusterPairElement = Settings->bQuietMissingClusterPairElement;
 
-	Context->bHasValidHeuristics = PCGExFactories::GetInputFactories(Context, PCGExHeuristics::Labels::SourceHeuristicsLabel, Context->HeuristicsFactories, {PCGExFactories::EType::Heuristics}, false);
+	Context->bHasValidHeuristics = PCGExFactories::GetInputFactories(Context, PCGExHeuristics::Labels::SourceHeuristicsLabel, Context->HeuristicsFactories, {FPCGExDataTypeInfoHeuristics::AsId()}, false);
 
 	Context->ClusterDataLibrary = MakeShared<PCGExClusters::FDataLibrary>(true);
 

--- a/Source/PCGExHeuristics/Public/Core/PCGExHeuristicsFactoryProvider.h
+++ b/Source/PCGExHeuristics/Public/Core/PCGExHeuristicsFactoryProvider.h
@@ -125,11 +125,6 @@ public:
 
 	FPCGExHeuristicConfigBase ConfigBase;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Heuristics;
-	}
-
 	virtual bool RegisterConsumableAttributesWithData(FPCGExContext* InContext, const UPCGData* InData) const override;
 
 	virtual TSharedPtr<FPCGExHeuristicOperation> CreateOperation(FPCGExContext* InContext) const;

--- a/Source/PCGExMatching/Private/Helpers/PCGExDataMatcher.cpp
+++ b/Source/PCGExMatching/Private/Helpers/PCGExDataMatcher.cpp
@@ -609,7 +609,7 @@ namespace PCGExMatching
 		TArray<TObjectPtr<const UPCGExMatchRuleFactoryData>> Factories;
 		if (!PCGExFactories::GetInputFactories(
 			InContext, InFactoriesLabel.IsNone() ? Labels::SourceMatchRulesLabel : InFactoriesLabel,
-			Factories, {PCGExFactories::EType::MatchRule}))
+			Factories, {FPCGExDataTypeInfoMatchRule::AsId()}))
 		{
 			MatchMode = EPCGExMapMatchMode::Disabled;
 			return false;

--- a/Source/PCGExMatching/Public/Core/PCGExMatchRuleFactoryProvider.h
+++ b/Source/PCGExMatching/Public/Core/PCGExMatchRuleFactoryProvider.h
@@ -112,11 +112,6 @@ public:
 		return false;
 	}
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::MatchRule;
-	}
-
 	virtual TSharedPtr<FPCGExMatchRuleOperation> CreateOperation(FPCGExContext* InContext) const;
 };
 

--- a/Source/PCGExNoise3D/Private/Helpers/PCGExNoiseGenerator.cpp
+++ b/Source/PCGExNoise3D/Private/Helpers/PCGExNoiseGenerator.cpp
@@ -14,7 +14,7 @@ namespace PCGExNoise3D
 	bool FNoiseGenerator::Init(FPCGExContext* InContext, const FName SourceLabel, bool bThrowError)
 	{
 		TArray<TObjectPtr<const UPCGExNoise3DFactoryData>> Factories;
-		if (!PCGExFactories::GetInputFactories(InContext, SourceLabel, Factories, {PCGExFactories::EType::Noise3D}, bThrowError))
+		if (!PCGExFactories::GetInputFactories(InContext, SourceLabel, Factories, {FPCGExDataTypeInfoNoise3D::AsId()}, bThrowError))
 		{
 			return false;
 		}

--- a/Source/PCGExNoise3D/Public/Core/PCGExNoise3DFactoryProvider.h
+++ b/Source/PCGExNoise3D/Public/Core/PCGExNoise3DFactoryProvider.h
@@ -124,11 +124,6 @@ public:
 
 	FPCGExNoise3DConfigBase ConfigBase;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::Noise3D;
-	}
-
 	virtual bool RegisterConsumableAttributesWithData(FPCGExContext* InContext, const UPCGData* InData) const override;
 
 	virtual TSharedPtr<FPCGExNoise3DOperation> CreateOperation(FPCGExContext* InContext) const;

--- a/Source/PCGExPickers/Public/Core/PCGExPickerFactoryProvider.h
+++ b/Source/PCGExPickers/Public/Core/PCGExPickerFactoryProvider.h
@@ -81,11 +81,6 @@ public:
 	UPROPERTY()
 	TArray<double> RelativePicks;
 
-	virtual PCGExFactories::EType GetFactoryType() const override
-	{
-		return PCGExFactories::EType::IndexPicker;
-	}
-
 	virtual void AddPicks(int32 InNum, TSet<int32>& OutPicks) const;
 
 	FPCGExPickerConfigBase BaseConfig;


### PR DESCRIPTION
PCGExFactories::EType enum was legacy carried over since... 5.3, allowed to keep parity between 5.6/5.7 but it's a needless constraint today. Cheap mechanical type change but huge blast radius.