### PR TITLE
[Graphs] Clarify edge IOIndex semantics and improve contracts

### DIFF
--- a/Source/PCGExCore/Private/Clusters/PCGExCluster.cpp
+++ b/Source/PCGExCore/Private/Clusters/PCGExCluster.cpp
@@ -258,15 +258,13 @@ namespace PCGExClusters
 		Edges->Reserve(NumRawEdges);
 		Edges->Append(InEdges);
 
-		// The shared, -1-initialized lookup (created fresh per graph compile) doubles as
-		// the point->node scratch: subgraphs partition vtx points (union-find components),
-		// so concurrent cluster builds each claim a disjoint set of indices, and the values
-		// written during creation ARE the lookup's final content. This replaces a per-cluster
-		// TSparseArray whose expansion cost scaled with the highest point index touched.
+		// Edge IOIndex is left as-is (parent-graph edge index); no cluster consumer reads it.
+
+		// Shared -1-initialized lookup doubles as point->node scratch: disjoint subgraph
+		// components let concurrent builds write it directly instead of using a TSparseArray.
 		BuildAdjacency_Unsafe(InNumNodes);
 
-		// Subgraph node counts are exact: every subgraph node is an endpoint of at
-		// least one of its edges (see FGraph::BuildSubGraphs).
+		// Exact: every subgraph node is an endpoint of one of its edges.
 		check(Nodes->Num() == InNumNodes)
 
 		Bounds = Bounds.ExpandBy(10);

--- a/Source/PCGExGraphs/Private/Graphs/PCGExGraph.cpp
+++ b/Source/PCGExGraphs/Private/Graphs/PCGExGraph.cpp
@@ -36,8 +36,14 @@ namespace PCGExGraphs
 
 	bool FGraph::InsertEdge_Unsafe(const int32 A, const int32 B, FEdge& OutEdge, const int32 IOIndex)
 	{
-		check(A != B)
-
+		
+#if WITH_EDITOR
+		if (!ensure(A != B))
+		{
+			return false;
+		}
+#endif
+		
 		const uint64 Hash = PCGEx::H64U(A, B);
 		if (const int32* EdgeIndex = UniqueEdges.Find(Hash))
 		{
@@ -112,9 +118,14 @@ namespace PCGExGraphs
 			}
 
 			PCGEx::H64(E, A, B);
-
-			check(A != B)
-
+			
+#if WITH_EDITOR
+			if (!ensure(A != B))
+			{
+				continue;
+			}
+#endif
+			
 			const int32 EdgeIndex = Edges.Emplace(Edges.Num(), A, B, -1, InIOIndex);
 
 			UniqueEdges.Add(E, EdgeIndex);
@@ -246,7 +257,12 @@ namespace PCGExGraphs
 
 			PCGEx::H64(E, A, B);
 
-			check(A != B)
+#if WITH_EDITOR
+			if (!ensure(A != B))
+			{
+				continue;
+			}
+#endif
 
 			const int32 EdgeIndex = Edges.Emplace(Edges.Num(), A, B);
 			UniqueEdges.Add(E, EdgeIndex);
@@ -335,7 +351,10 @@ namespace PCGExGraphs
 		TArray<int32> Parent;
 		Parent.SetNumUninitialized(NumNodes);
 		int32* ParentData = Parent.GetData();
-		PCGExMT::ParallelOrSequential(NumNodes, [&](const int32 i) { ParentData[i] = i; });
+		PCGExMT::ParallelOrSequential(NumNodes, [&](const int32 i)
+		{
+			ParentData[i] = i;
+		});
 
 		// Iterative find with opportunistic CAS path-halving. Links always attach the
 		// larger root under the smaller one, so parents only ever move toward smaller

--- a/Source/PCGExGraphs/Private/Graphs/PCGExSubGraph.cpp
+++ b/Source/PCGExGraphs/Private/Graphs/PCGExSubGraph.cpp
@@ -125,8 +125,7 @@ namespace PCGExGraphs
 
 	void FSubGraph::BuildCluster(const TSharedRef<PCGExClusters::FCluster>& InCluster)
 	{
-		// Correct edge IO Index that has been overwritten during subgraph processing
-		PCGEX_PARALLEL_FOR(FlattenedEdges.Num(), FlattenedEdges[i].IOIndex = -1;)
+		// FlattenedEdges is immutable after Compile (read concurrently by post-compile callbacks).
 		InCluster->BuildFromSubgraphData(VtxDataFacade, EdgesDataFacade, FlattenedEdges, Nodes.Num());
 
 		// Look into the cost of this
@@ -243,7 +242,8 @@ namespace PCGExGraphs
 					{
 						const FEdge& OE = ParentGraphEdges[Edges[i].Index];
 
-						// Hijack edge IOIndex to store original edge index in the flattened
+						// IOIndex = parent-graph edge index: the flattened edge's stable identity
+						// (see the FlattenedEdges contract in the header)
 						FlattenedEdges[i] = FEdge(i, ParentGraphNodes[OE.Start].PointIndex, ParentGraphNodes[OE.End].PointIndex, i, OE.Index);
 
 						const int32 OriginalPointIndex = OE.PointIndex;

--- a/Source/PCGExGraphs/Public/Graphs/PCGExSubGraph.h
+++ b/Source/PCGExGraphs/Public/Graphs/PCGExSubGraph.h
@@ -48,6 +48,12 @@ namespace PCGExGraphs
 		TSet<int32> EdgesInIOIndices;
 		TSharedPtr<PCGExData::FFacade> VtxDataFacade;
 		TSharedPtr<PCGExData::FFacade> EdgesDataFacade;
+
+		/**
+		 * Output-space edges built by Compile (1:1 with Edges). Start/End are OUTPUT vtx
+		 * point indices (post-prune/reorder); IOIndex is the parent-graph edge index.
+		 * Immutable once Compile has run -- read concurrently by cluster build and callbacks.
+		 */
 		TArray<FEdge> FlattenedEdges;
 		int32 UID = 0;
 		int32 MinPointIndex = MAX_int32;


### PR DESCRIPTION
- Remove incorrect IOIndex initialization in FlattenedEdges (was overwriting to -1). IOIndex should preserve the parent-graph edge index as the stable identity for flattened edges.
- Change fatal check() assertions to editor-only ensure() in graph building to gracefully handle degenerate inputs.