### PR TITLE
[Properties] Fix use-after-free crash in import override reconciliation

### DIFF
--- a/Source/PCGExPropertiesEditor/Private/Details/PCGExPropertySchemaCollectionCustomization.cpp
+++ b/Source/PCGExPropertiesEditor/Private/Details/PCGExPropertySchemaCollectionCustomization.cpp
@@ -204,15 +204,14 @@ void FPCGExPropertySchemaCollectionCustomization::OnSchemasArrayChanged()
 	{
 		Schema.SyncPropertyName();
 	}
-	Collection->ReconcileImportOverrides();
+	ReconcileImportOverridesPreservingLiveRows(*Collection);
 
 	CachedResolvedCount = -1;
-	// Deferred refresh: ForceRefresh from inside a property change notification tears down the
-	// widget tree mid-stack-unwind, killing the FInstancedStruct picker's in-flight transaction
-	// and breaking undo. Same trap FPCGExPropertyOverridesCustomization documents.
+	// Deferred rebuild. RequestRefresh only re-lays-out existing rows (never re-runs this customization
+	// -> stale list); a synchronous ForceRefresh from inside a change notification would re-enter.
 	if (TSharedPtr<IPropertyUtilities> PropertyUtilities = WeakPropertyUtilities.Pin())
 	{
-		PropertyUtilities->RequestRefresh();
+		PropertyUtilities->RequestForceRefresh();
 	}
 }
 
@@ -228,14 +227,14 @@ void FPCGExPropertySchemaCollectionCustomization::OnImportedSchemasArrayChanged(
 	PropertyHandle->AccessRawData(RawData);
 	if (!RawData.IsEmpty() && RawData[0])
 	{
-		static_cast<FPCGExPropertySchemaCollection*>(RawData[0])->ReconcileImportOverrides();
+		ReconcileImportOverridesPreservingLiveRows(*static_cast<FPCGExPropertySchemaCollection*>(RawData[0]));
 	}
 
 	CachedResolvedCount = -1;
-	// Deferred refresh -- see OnSchemasArrayChanged.
+	// Deferred rebuild -- see OnSchemasArrayChanged.
 	if (TSharedPtr<IPropertyUtilities> PropertyUtilities = WeakPropertyUtilities.Pin())
 	{
-		PropertyUtilities->RequestRefresh();
+		PropertyUtilities->RequestForceRefresh();
 	}
 }
 
@@ -270,23 +269,30 @@ void FPCGExPropertySchemaCollectionCustomization::ReconcileAndNotify()
 	PropertyHandle->AccessRawData(RawData);
 	if (!RawData.IsEmpty() && RawData[0])
 	{
-		static_cast<FPCGExPropertySchemaCollection*>(RawData[0])->ReconcileImportOverrides();
+		ReconcileImportOverridesPreservingLiveRows(*static_cast<FPCGExPropertySchemaCollection*>(RawData[0]));
 	}
 
-	PropertyHandle->NotifyPostChange(EPropertyChangeType::ValueSet);
+	PropertyHandle->NotifyPostChange(EPropertyChangeType::ValueSet); // mark host dirty to re-serialise
 
-	// ForceRefresh, not RequestRefresh: when this handler fires from an upstream asset's
-	// OnSchemaAssetChanged broadcast (e.g. A adds an entry, B is open and subscribed), the
-	// deferred RequestRefresh path doesn't reliably tick through to a rebuild from inside
-	// the broadcast event chain -- the rebuild only fires when the detail panel is otherwise
-	// invalidated (editor close/reopen). ForceRefresh runs the rebuild synchronously, which
-	// the sibling array-change handlers (OnSchemasArrayChanged, OnImportedSchemasArrayChanged)
-	// already use without re-entrancy issues.
+	// Fires from an imported asset's broadcast -> deferred rebuild (synchronous ForceRefresh would
+	// re-enter mid-broadcast; RequestRefresh wouldn't re-run this customization -> stale).
 	CachedResolvedCount = -1;
 	if (TSharedPtr<IPropertyUtilities> PropertyUtilities = WeakPropertyUtilities.Pin())
 	{
-		PropertyUtilities->ForceRefresh();
+		PropertyUtilities->RequestForceRefresh();
 	}
+}
+
+void FPCGExPropertySchemaCollectionCustomization::ReconcileImportOverridesPreservingLiveRows(FPCGExPropertySchemaCollection& Collection)
+{
+	// Mounted rows alias each Overrides[i].Value's inner memory via non-owning FStructOnScope and repaint
+	// from it, so reconciling in place (SyncToSchema's slow path frees it) is a use-after-free until the
+	// deferred rebuild tears them down. Park the entries -- a TArray move leaves their inner allocations
+	// put -- and reconcile a copy instead. Stays in the caller's transaction, so undo is unaffected.
+	TArray<FPCGExPropertyOverrideEntry>& Parked = ParkedOverrideBuffers.AddDefaulted_GetRef();
+	Parked = MoveTemp(Collection.ImportOverrides.Overrides);
+	Collection.ImportOverrides.Overrides = Parked; // copy back for the reconcile to reallocate
+	Collection.ReconcileImportOverrides();
 }
 
 void FPCGExPropertySchemaCollectionCustomization::EmitSectionHeader(IDetailChildrenBuilder& ChildBuilder, const FString& Title) const

--- a/Source/PCGExPropertiesEditor/Public/Details/PCGExPropertySchemaCollectionCustomization.h
+++ b/Source/PCGExPropertiesEditor/Public/Details/PCGExPropertySchemaCollectionCustomization.h
@@ -5,6 +5,7 @@
 
 #include "IPropertyTypeCustomization.h"
 #include "UObject/StructOnScope.h"
+#include "PCGExProperty.h" // FPCGExPropertyOverrideEntry (ParkedOverrideBuffers member)
 
 class IDetailPropertyRow;
 class IPropertyUtilities;
@@ -81,6 +82,9 @@ private:
 	 */
 	void ReconcileAndNotify();
 
+	/** ReconcileImportOverrides without freeing memory the still-mounted rows alias (see .cpp). */
+	void ReconcileImportOverridesPreservingLiveRows(FPCGExPropertySchemaCollection& Collection);
+
 	/** Subscribe to OnSchemaAssetChanged on every asset reachable through ImportedSchemas (BFS). */
 	void SubscribeToImportedAssets();
 
@@ -137,6 +141,10 @@ private:
 
 	/** Active OnSchemaAssetChanged subscriptions. Cleared on customization teardown / rebuild. */
 	TArray<TPair<TWeakObjectPtr<UPCGExPropertySchemaAsset>, FDelegateHandle>> AssetDelegateHandles;
+
+	/** Old override buffers kept alive so rows aliasing their memory outlive a reallocating reconcile;
+	 *  each dies with this customization instance, after the rebuild disconnects those rows. */
+	TArray<TArray<FPCGExPropertyOverrideEntry>> ParkedOverrideBuffers;
 
 	/** Cached resolved entry count for GetHeaderText (called per Slate redraw). -1 means unset. */
 	mutable int32 CachedResolvedCount = -1;


### PR DESCRIPTION
The import-override rows alias each ImportOverrides.Overrides[i].Value through non-owning FStructOnScopes. When the import count changed, ReconcileImportOverrides would free that aliased memory, causing a use-after-free crash during repaint until the (deferred) rebuild tore down the rows.

Fix by parking the current entries before reconciliation so their inner FInstancedStruct allocations outlive the rows, then reconciling an equivalent copy. This keeps all aliases valid across the reconcile.