### PR TITLE
[Collections] Persistent machinery state with per-type lifecycle hooks

### DIFF
--- a/Source/PCGExCollections/Private/Collections/PCGExOmniCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExOmniCollection.cpp
@@ -42,7 +42,9 @@ namespace PCGExOmniCollection
 			});
 
 			// TypeId -> globals-block struct for the built-in types; registered here so the
-			// per-collection macro signature stays untouched.
+			// per-collection macro signature stays untouched. PCGDataAsset registers its own
+			// globals + machinery StateClass in PCGExPCGDataAssetCollection.cpp (Phase C1 --
+			// colocated with the machinery it describes).
 			{
 				using FTypeRegistry = PCGExAssetCollection::FTypeRegistry;
 				using FTypeInfo = PCGExAssetCollection::FTypeInfo;
@@ -52,13 +54,6 @@ namespace PCGExOmniCollection
 				FTypeRegistry::AddPendingCustomization(TypeIds::SkinnedMesh, [](FTypeInfo& Info) { Info.GlobalsStruct = FPCGExSkinnedMeshCollectionGlobals::StaticStruct(); });
 				FTypeRegistry::AddPendingCustomization(TypeIds::Actor, [](FTypeInfo& Info) { Info.GlobalsStruct = FPCGExActorCollectionGlobals::StaticStruct(); });
 				FTypeRegistry::AddPendingCustomization(TypeIds::Level, [](FTypeInfo& Info) { Info.GlobalsStruct = FPCGExLevelCollectionGlobals::StaticStruct(); });
-				FTypeRegistry::AddPendingCustomization(TypeIds::PCGDataAsset, [](FTypeInfo& Info)
-				{
-					Info.GlobalsStruct = FPCGExPCGDataAssetCollectionGlobals::StaticStruct();
-					// Machinery state/processor: hosts carrying this run the PCGData shared
-					// compaction / collection maps / externalization for their PCGData entries.
-					Info.StateClass = UPCGExPCGDataTypeState::StaticClass();
-				});
 			}
 
 #if WITH_EDITOR
@@ -524,6 +519,7 @@ int32 UPCGExOmniCollection::EDITOR_AppendCollections(TConstArrayView<UPCGExAsset
 		const int32 RowStart = Entries.Num();
 		int32 SourceAppended = 0;
 		int32 SourceSkipped = 0;
+		TSet<PCGExAssetCollection::FTypeId> SourceLeafTypeIds;
 
 		Source->ForEachEntry([&](const FPCGExAssetCollectionEntry* Entry, const int32 Index)
 		{
@@ -550,6 +546,8 @@ int32 UPCGExOmniCollection::EDITOR_AppendCollections(TConstArrayView<UPCGExAsset
 
 			if (!Payload->bIsSubCollection)
 			{
+				SourceLeafTypeIds.Add(Payload->GetTypeId());
+
 				for (const UScriptStruct* Bake : BakeStructs)
 				{
 					if (CoversEntry(Bake, Payload))
@@ -562,6 +560,18 @@ int32 UPCGExOmniCollection::EDITOR_AppendCollections(TConstArrayView<UPCGExAsset
 
 			SourceAppended++;
 		});
+
+		// Ensure per-type STATES for what THIS source contributed, seeding newly created
+		// ones from it (adopts external-storage settings -- closes the gap where merged
+		// PCGData machinery silently fell back to embedded). Must run per source, before the
+		// tail rebuild's seedless safety net would create the states with bare defaults.
+		// Deliberately states-only: installing globals BLOCKS mid-call would corrupt the
+		// block conflict resolution for later sources (see EDITOR_EnsureTypeStateForType);
+		// blocks arrive with the tail rebuild's full ensure.
+		for (const PCGExAssetCollection::FTypeId LeafTypeId : SourceLeafTypeIds)
+		{
+			EDITOR_EnsureTypeStateForType(LeafTypeId, Source);
+		}
 
 		// Row ranges for blocks this source installed -- retro-bake targets on later conflicts.
 		for (FInstalledBlock& Installed : InstalledThisCall)
@@ -677,7 +687,7 @@ bool UPCGExOmniCollection::EDITOR_EnsureTypeSetup()
 	return bAdded;
 }
 
-bool UPCGExOmniCollection::EDITOR_EnsureTypeSetupForType(const PCGExAssetCollection::FTypeId TypeId)
+bool UPCGExOmniCollection::EDITOR_EnsureTypeSetupForType(const PCGExAssetCollection::FTypeId TypeId, const UPCGExAssetCollection* SeedSource)
 {
 	// Lineage-resolved: a type registering no GlobalsStruct/StateClass of its own inherits
 	// its nearest ancestor's -- consistent with the staging capability guard
@@ -722,16 +732,37 @@ bool UPCGExOmniCollection::EDITOR_EnsureTypeSetupForType(const PCGExAssetCollect
 		}
 	}
 
-	// Machinery state; class defaults mirror the typed collection's members. Slot-based
-	// existence check so an occupied slot (e.g. a derived state) is never doubled up.
-	if (Info.StateClass.IsValid() && !FindTypeStateForSlot(Info.StateClass.Get()))
-	{
-		Modify();
-		TypeStates.Add(NewObject<UPCGExCollectionTypeState>(this, Info.StateClass.Get(), NAME_None, RF_Transactional));
-		bAdded = true;
-	}
+	bAdded |= EDITOR_EnsureTypeStateForType(TypeId, SeedSource);
 
 	return bAdded;
+}
+
+bool UPCGExOmniCollection::EDITOR_EnsureTypeStateForType(const PCGExAssetCollection::FTypeId TypeId, const UPCGExAssetCollection* SeedSource)
+{
+	PCGExAssetCollection::FTypeInfo Info;
+	if (!PCGExAssetCollection::FTypeRegistry::Get().GetInfoResolved(TypeId, Info) || !Info.StateClass.IsValid())
+	{
+		return false;
+	}
+
+	// Slot-based existence check so an occupied slot (e.g. a derived state) is never
+	// doubled up. An existing state is the user's and always wins -- but it gets to SEE a
+	// skipped seed so real conflicts (e.g. differing external-storage settings) surface.
+	if (UPCGExCollectionTypeState* Existing = FindTypeStateForSlot(Info.StateClass.Get()))
+	{
+		if (SeedSource)
+		{
+			Existing->OnSeedSourceIgnored(this, SeedSource);
+		}
+		return false;
+	}
+
+	// Machinery state; class defaults mirror the typed collection's members. Fresh states
+	// may adopt the seed source's settings (merge/conversion).
+	Modify();
+	UPCGExCollectionTypeState* NewState = TypeStates.Add_GetRef(NewObject<UPCGExCollectionTypeState>(this, Info.StateClass.Get(), NAME_None, RF_Transactional));
+	NewState->OnAddedToHost(this, SeedSource);
+	return true;
 }
 
 void UPCGExOmniCollection::GetCookDependencyAssetPaths(TSet<FSoftObjectPath>& OutPaths) const
@@ -849,12 +880,17 @@ int32 UPCGExOmniCollection::EDITOR_CleanupUnusedTypeSetup()
 
 	for (int32 i = TypeStates.Num() - 1; i >= 0; --i)
 	{
-		const UPCGExCollectionTypeState* State = TypeStates[i];
+		UPCGExCollectionTypeState* State = TypeStates[i];
 		const UClass* StateClass = State ? State->GetClass() : nullptr;
 
 		if (!State || (AnySlotMatch(RegisteredStates, StateClass) && !AnySlotMatch(NeededStates, StateClass)))
 		{
 			EnsureModify();
+			if (State)
+			{
+				// Teardown surface (e.g. warn about externalized packages that will orphan).
+				State->OnRemovedFromHost(this);
+			}
 			TypeStates.RemoveAt(i);
 			Removed++;
 		}

--- a/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
+++ b/Source/PCGExCollections/Private/Collections/PCGExPCGDataAssetCollection.cpp
@@ -37,6 +37,31 @@
 // Static-init type registration: TypeId=PCGDataAsset, parent=Base
 PCGEX_REGISTER_COLLECTION_TYPE(PCGDataAsset, UPCGExPCGDataAssetCollection, FPCGExPCGDataAssetCollectionEntry, "PCG Data Asset Collection", Base)
 
+// Machinery registration: TypeId -> globals block + state class. Colocated with the type
+// (moved here from PCGExOmniCollection.cpp in Phase C1 -- the typed collection owns a
+// UPCGExPCGDataTypeState itself now, so the capability data lives where the machinery does;
+// third-party types with machinery register theirs the same way, in their own module).
+namespace PCGExPCGDataAssetCollection
+{
+	struct FMachineryRegistration
+	{
+		FMachineryRegistration()
+		{
+			PCGExAssetCollection::FTypeRegistry::AddPendingCustomization(
+				PCGExAssetCollection::TypeIds::PCGDataAsset,
+				[](PCGExAssetCollection::FTypeInfo& Info)
+				{
+					Info.GlobalsStruct = FPCGExPCGDataAssetCollectionGlobals::StaticStruct();
+					// Hosts carrying this state run the PCGData shared compaction /
+					// collection maps / externalization for their PCGData entries.
+					Info.StateClass = UPCGExPCGDataTypeState::StaticClass();
+				});
+		}
+	};
+
+	FMachineryRegistration GMachineryRegistration;
+}
+
 #pragma region FPCGExPCGDataAssetCollectionEntry
 
 bool FPCGExPCGDataAssetCollectionEntry::Validate(const UPCGExAssetCollection* ParentCollection)
@@ -973,6 +998,58 @@ namespace PCGExSharedCompact
 
 #pragma region UPCGExPCGDataAssetCollection
 
+UPCGExPCGDataAssetCollection::UPCGExPCGDataAssetCollection()
+{
+	// Always-present machinery state (Phase C1). Default subobject: delta-serializes against
+	// the CDO's, inherits RF_Transactional from the asset (RF_PropagateToSubObjects), and
+	// guarantees the nested "External Storage" details block is never None.
+	MachineryState = CreateDefaultSubobject<UPCGExPCGDataTypeState>(TEXT("MachineryState"));
+}
+
+void UPCGExPCGDataAssetCollection::PostLoad()
+{
+	Super::PostLoad();
+
+	// Phase C1 migration (2026-07-19): the machinery members moved into MachineryState.
+	// The deprecated slots still LOAD legacy data (UHT registers them under their unsuffixed
+	// names with CPF_Deprecated: tagged properties match, saves always skip) -- move the
+	// values over once and clear. Referenced subobjects keep their outer (this collection),
+	// the state only holds the refs -- same shape as an Omni host.
+	if (MachineryState)
+	{
+		if (bUseExternalAssets_DEPRECATED)
+		{
+			MachineryState->bUseExternalAssets = true;
+			bUseExternalAssets_DEPRECATED = false;
+		}
+		if (!ExportFolder_DEPRECATED.Path.IsEmpty())
+		{
+			MachineryState->ExportFolder = ExportFolder_DEPRECATED;
+			ExportFolder_DEPRECATED.Path.Reset();
+		}
+		if (SharedMeshCollection_DEPRECATED)
+		{
+			MachineryState->SharedMeshCollection = SharedMeshCollection_DEPRECATED;
+			SharedMeshCollection_DEPRECATED = nullptr;
+		}
+		if (SharedLevelCollection_DEPRECATED)
+		{
+			MachineryState->SharedLevelCollection = SharedLevelCollection_DEPRECATED;
+			SharedLevelCollection_DEPRECATED = nullptr;
+		}
+		if (!ExternalSharedMeshCollection_DEPRECATED.IsNull())
+		{
+			MachineryState->ExternalSharedMeshCollection = ExternalSharedMeshCollection_DEPRECATED;
+			ExternalSharedMeshCollection_DEPRECATED.Reset();
+		}
+		if (!ExternalSharedLevelCollection_DEPRECATED.IsNull())
+		{
+			MachineryState->ExternalSharedLevelCollection = ExternalSharedLevelCollection_DEPRECATED;
+			ExternalSharedLevelCollection_DEPRECATED.Reset();
+		}
+	}
+}
+
 bool UPCGExPCGDataAssetCollection::GetTypeGlobalsInternal(const UScriptStruct* StructType, FPCGExCollectionTypeGlobals& OutGlobals) const
 {
 	if (!StructType || !StructType->IsChildOf(FPCGExPCGDataAssetCollectionGlobals::StaticStruct()))
@@ -985,29 +1062,6 @@ bool UPCGExPCGDataAssetCollection::GetTypeGlobalsInternal(const UScriptStruct* S
 	Out.LevelExporter = LevelExporter;
 #endif
 	return true;
-}
-
-FPCGExPCGDataAssetMachinery UPCGExPCGDataAssetCollection::MakeMachinery()
-{
-	FPCGExPCGDataAssetMachinery State;
-	State.Host = this;
-
-	State.Entries.Reserve(Entries.Num());
-	for (FPCGExPCGDataAssetCollectionEntry& Entry : Entries)
-	{
-		State.Entries.Add(&Entry);
-	}
-
-	State.SharedMeshCollection = &SharedMeshCollection;
-	State.SharedLevelCollection = &SharedLevelCollection;
-	State.ExternalSharedMeshCollection = &ExternalSharedMeshCollection;
-	State.ExternalSharedLevelCollection = &ExternalSharedLevelCollection;
-
-	State.bExternalActive = IsExternalActive();
-	State.ExportFolderPath = ExportFolder.Path;
-	State.ExternalAssetPrefix = MakeExternalAssetPrefixFor(this);
-
-	return State;
 }
 
 bool UPCGExPCGDataAssetCollection::HostSupportsDataAssetMachinery(const UPCGExAssetCollection* Host)
@@ -1261,26 +1315,24 @@ void UPCGExPCGDataAssetCollection::RebuildSharedCollectionsFor(FPCGExPCGDataAsse
 	ExternalizeExportedDataAssetsFor(State);
 }
 
-void UPCGExPCGDataAssetCollection::InternalizeSubobjects()
-{
-#if WITH_EDITOR
-	FPCGExPCGDataAssetMachinery State = MakeMachinery();
-	InternalizeSubobjectsFor(State);
-#endif
-}
-
 void UPCGExPCGDataAssetCollection::SaveExternalPackages()
 {
 #if WITH_EDITOR
-	FPCGExPCGDataAssetMachinery State = MakeMachinery();
-	SaveExternalPackagesFor(State);
+	if (MachineryState)
+	{
+		FPCGExPCGDataAssetMachinery State = MachineryState->MakeMachinery(this);
+		SaveExternalPackagesFor(State);
+	}
 #endif
 }
 
 void UPCGExPCGDataAssetCollection::RebuildSharedCollections()
 {
-	FPCGExPCGDataAssetMachinery State = MakeMachinery();
-	RebuildSharedCollectionsFor(State);
+	if (MachineryState)
+	{
+		FPCGExPCGDataAssetMachinery State = MachineryState->MakeMachinery(this);
+		RebuildSharedCollectionsFor(State);
+	}
 }
 
 void UPCGExPCGDataAssetCollection::ScrubSharedRefsForSave(TObjectPtr<UPCGExMeshCollection>& MeshSlot, TObjectPtr<UPCGExLevelCollection>& LevelSlot, FPCGExPCGDataSharedScrubKeep& OutKeep)
@@ -1335,67 +1387,47 @@ void UPCGExPCGDataAssetCollection::RestoreEntryRefsAfterSave(FPCGExPCGDataEntryS
 
 void UPCGExPCGDataAssetCollection::Serialize(FArchive& Ar)
 {
-	// External mode: the Instanced fields are working buffers during the editor session -- their
-	// targets live in separate external packages once externalization has run. Without this
-	// scrub, UE's Instanced-property serializer would chase those pointers and bake hard
-	// references into our saved package, eagerly loading every external asset alongside us
-	// and defeating the lazy-load goal. Soft refs + Staging.Path remain the on-disk addresses.
-	// Skipped for transacting (undo/redo) so the transaction buffer can round-trip the in-memory
-	// state without loss.
-	if (IsExternalActive() && Ar.IsSaving() && !Ar.IsTransacting())
+	// Host-side entry-ref scrub around the save, dispatched to the machinery state -- the
+	// exact code path an Omni host runs. Begin gates on external-active internally; the
+	// state scrubs its OWN shared members in its own Serialize (it is a separate package
+	// export, serialized by SavePackage outside this pair -- under the same save, so its
+	// own gate holds).
+	const bool bScrub = Ar.IsSaving() && !Ar.IsTransacting() && MachineryState;
+
+	if (bScrub)
 	{
-		FPCGExPCGDataSharedScrubKeep SharedKeep;
-		FPCGExPCGDataEntryScrubKeep EntryKeep;
-
-		ScrubSharedRefsForSave(SharedMeshCollection, SharedLevelCollection, SharedKeep);
-		ScrubEntryRefsForSave(MakeMachinery().Entries, EntryKeep);
-
-		Super::Serialize(Ar);
-
-		RestoreSharedRefsAfterSave(SharedKeep);
-		RestoreEntryRefsAfterSave(EntryKeep);
-		return;
+		MachineryState->OnHostSerializeSave_Begin(this);
 	}
 
 	Super::Serialize(Ar);
+
+	if (bScrub)
+	{
+		MachineryState->OnHostSerializeSave_End(this);
+	}
 }
 
 void UPCGExPCGDataAssetCollection::PostDuplicate(bool bDuplicateForPIE)
 {
+	// Super first: the duplicate's CollectionGUID must be regenerated before the state
+	// re-stamps anything keyed to it.
 	Super::PostDuplicate(bDuplicateForPIE);
 
-	// On a real duplicate (not PIE), both this collection AND its outered shared collections
-	// receive new CollectionGUIDs while per-entry ExportedDataAssets still carry hashes keyed
-	// to the ORIGINAL shared GUIDs. Re-stamp them so the duplicate is consistent without a
-	// manual rebuild.
-	if (!bDuplicateForPIE)
+	if (MachineryState)
 	{
-		RebuildSharedCollections();
+		MachineryState->OnHostPostDuplicate(this, bDuplicateForPIE);
 	}
 }
 
 void UPCGExPCGDataAssetCollection::PreSave(FObjectPreSaveContext ObjectSaveContext)
 {
-	// Cook-time safety net for users who edited a source level and cooked without a manual
-	// rebuild (or recovered from a mid-edit editor crash). Idempotent.
-	//
-	// Only re-bake the IN-MEMORY state here. 
-	// We deliberately do NOT call SaveExternalPackages() during cook:
-	//  - SavePackage(Pkg, nullptr, ...) is an editor (uncooked) save that writes the SOURCE
-	//    .uasset under /Content/. A cook must be read-only w.r.t. source content; writing it
-	//    dirties the workspace and fails / forces a writable-flip on read-only (Perforce) files.
-	//  - It mutates packages the cooker may have already cooked (no effect) or not yet cooked
-	//    (changing the source mid-cook), making the output depend on cook scheduling.
-	//  - In concurrent / cook-by-the-book saving, GIsSavingPackage is held for the whole batch;
-	//    a nested non-concurrent SavePackage clears it on scope-exit, breaking that invariant.
-	// On most cases (except for potential multi-threaded cooks), external objects are
-	// cooked from the loaded in-memory ones which should be enough.
-	// Actually might want to consider just removing this as the levels aren't actually being re-harvested
-	// at all here so the safety net is not quite comprehensive in the first place.
-	if (ObjectSaveContext.IsCooking())
+	// Cook-time safety net -- gated and explained in UPCGExPCGDataTypeState::OnHostPreSave
+	// (including why SaveExternalPackages is deliberately NOT called during cook).
+	if (MachineryState)
 	{
-		RebuildSharedCollections();
+		MachineryState->OnHostPreSave(this, ObjectSaveContext);
 	}
+
 	Super::PreSave(ObjectSaveContext);
 }
 
@@ -1403,29 +1435,9 @@ void UPCGExPCGDataAssetCollection::PreSave(FObjectPreSaveContext ObjectSaveConte
 
 void UPCGExPCGDataAssetCollection::EDITOR_OnPostStagingRebuild()
 {
-	RebuildSharedCollections();
-}
-
-void UPCGExPCGDataAssetCollection::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
-{
-	Super::PostEditChangeProperty(PropertyChangedEvent);
-
-	const FName PropName = PropertyChangedEvent.Property ? PropertyChangedEvent.Property->GetFName() : NAME_None;
-	const bool bToggledExternal = (PropName == GET_MEMBER_NAME_CHECKED(UPCGExPCGDataAssetCollection, bUseExternalAssets));
-	const bool bChangedFolder = (PropName == GET_MEMBER_NAME_CHECKED(UPCGExPCGDataAssetCollection, ExportFolder));
-
-	if (bToggledExternal && !bUseExternalAssets)
+	if (MachineryState)
 	{
-		// External -> Embedded: pull subobjects back into the collection package, null soft
-		// refs, then re-bake the CollectionMap with the now-inner paths.
-		InternalizeSubobjects();
-		RebuildSharedCollections();
-	}
-	else if (bToggledExternal || bChangedFolder)
-	{
-		// Embedded -> External, or External folder moved: re-externalize using the
-		// (new) settings. CompactShared's load-back rehydrates the working buffers.
-		RebuildSharedCollections();
+		MachineryState->EDITOR_OnHostPostStagingRebuild(this);
 	}
 }
 
@@ -1543,20 +1555,14 @@ void UPCGExPCGDataAssetCollection::GetCookDependencyAssetPaths(TSet<FSoftObjectP
 {
 	// Base = each entry's Staging.Path. For Level-sourced entries that path is the embedded
 	// (or repointed external) ExportedDataAsset; for DataAsset-sourced entries it's the
-	// user-referenced UPCGDataAsset.
+	// user-referenced UPCGDataAsset. The machinery refs (shared collections, externals,
+	// per-entry actor collections) come from the state dispatch.
 	Super::GetCookDependencyAssetPaths(OutPaths);
 
-	TArray<const FPCGExPCGDataAssetCollectionEntry*> EntryPtrs;
-	EntryPtrs.Reserve(Entries.Num());
-	for (const FPCGExPCGDataAssetCollectionEntry& Entry : Entries)
+	if (MachineryState)
 	{
-		EntryPtrs.Add(&Entry);
+		MachineryState->AppendCookDependencyAssetPaths(this, OutPaths);
 	}
-
-	AppendCookDependencyAssetPathsFor(
-		SharedMeshCollection, SharedLevelCollection,
-		ExternalSharedMeshCollection, ExternalSharedLevelCollection,
-		EntryPtrs, OutPaths);
 }
 #endif
 
@@ -1595,8 +1601,21 @@ FPCGExPCGDataAssetMachinery UPCGExPCGDataTypeState::MakeMachinery(UPCGExAssetCol
 
 void UPCGExPCGDataTypeState::OnHostPreSave(UPCGExAssetCollection* Host, FObjectPreSaveContext SaveContext)
 {
-	// Cook-time safety net -- mirrors UPCGExPCGDataAssetCollection::PreSave (see there for
-	// why SaveExternalPackages is deliberately NOT called during cook).
+	// Cook-time safety net for users who edited a source level and cooked without a manual
+	// rebuild (or recovered from a mid-edit editor crash). Idempotent.
+	//
+	// Only re-bake the IN-MEMORY state here.
+	// We deliberately do NOT call SaveExternalPackages during cook:
+	//  - SavePackage(Pkg, nullptr, ...) is an editor (uncooked) save that writes the SOURCE
+	//    .uasset under /Content/. A cook must be read-only w.r.t. source content; writing it
+	//    dirties the workspace and fails / forces a writable-flip on read-only (Perforce) files.
+	//  - It mutates packages the cooker may have already cooked (no effect) or not yet cooked
+	//    (changing the source mid-cook), making the output depend on cook scheduling.
+	//  - In concurrent / cook-by-the-book saving, GIsSavingPackage is held for the whole batch;
+	//    a nested non-concurrent SavePackage clears it on scope-exit, breaking that invariant.
+	// In most cases (except potential multi-threaded cooks), external objects are cooked from
+	// the loaded in-memory ones, which should be enough. NOTE: levels are not re-harvested
+	// here, so this net is not comprehensive -- kept as a best-effort re-bake.
 	if (SaveContext.IsCooking())
 	{
 		FPCGExPCGDataAssetMachinery State = MakeMachinery(Host);
@@ -1709,6 +1728,70 @@ void UPCGExPCGDataTypeState::PostEditChangeProperty(FPropertyChangedEvent& Prope
 			FPCGExPCGDataAssetMachinery State = MakeMachinery(Host);
 			UPCGExPCGDataAssetCollection::InternalizeSubobjectsFor(State);
 		}
+	}
+}
+
+void UPCGExPCGDataTypeState::OnAddedToHost(UPCGExAssetCollection* Host, const UPCGExAssetCollection* SeedSource)
+{
+	// Adopt the seed source's external-storage SETTINGS on creation (closes the merge gap:
+	// converting/merging a PCGData source into an Omni used to silently fall back to
+	// embedded). Only fires on FRESH states -- an existing state is the user's and always
+	// wins (behavior-wins, like globals-block merging). Only settings transfer: shared
+	// collections are session buffers, and External* soft refs address the SOURCE's own
+	// external packages -- adopting them would alias another asset's storage. Sharing the
+	// source's ExportFolder is safe: external names are host-GUID-prefixed.
+	if (!SeedSource)
+	{
+		return;
+	}
+
+	const UPCGExPCGDataTypeState* SourceState = SeedSource->FindTypeState<UPCGExPCGDataTypeState>();
+	if (!SourceState || !SourceState->bUseExternalAssets)
+	{
+		return;
+	}
+
+	bUseExternalAssets = SourceState->bUseExternalAssets;
+	ExportFolder = SourceState->ExportFolder;
+
+	UE_LOG(LogPCGEx, Log,
+	       TEXT("'%s': ensured PCG Data Asset machinery adopted external-storage settings (folder '%s') from source '%s'."),
+	       Host ? *Host->GetName() : TEXT("<null>"), *ExportFolder.Path, *SeedSource->GetName());
+}
+
+void UPCGExPCGDataTypeState::OnSeedSourceIgnored(UPCGExAssetCollection* Host, const UPCGExAssetCollection* SeedSource)
+{
+	// First-creator-wins must not be silent when it drops real configuration: if the ignored
+	// source ran external storage and this state's settings differ, the merged entries will
+	// compact/externalize under THIS state's rules -- say so, so the author can re-apply the
+	// source's settings deliberately.
+	const UPCGExPCGDataTypeState* SourceState = SeedSource ? SeedSource->FindTypeState<UPCGExPCGDataTypeState>() : nullptr;
+	if (!SourceState || !SourceState->bUseExternalAssets)
+	{
+		return;
+	}
+
+	if (bUseExternalAssets != SourceState->bUseExternalAssets || ExportFolder.Path != SourceState->ExportFolder.Path)
+	{
+		UE_LOG(LogPCGEx, Warning,
+		       TEXT("'%s': merged source '%s' used external storage (folder '%s'), but this collection's existing PCG Data Asset machinery settings win (%s). Re-apply the source's settings manually if that was intended."),
+		       Host ? *Host->GetName() : TEXT("<null>"), *SeedSource->GetName(), *SourceState->ExportFolder.Path,
+		       bUseExternalAssets ? *FString::Printf(TEXT("external, folder '%s'"), *ExportFolder.Path) : TEXT("embedded"));
+	}
+}
+
+void UPCGExPCGDataTypeState::OnRemovedFromHost(UPCGExAssetCollection* Host)
+{
+	// Teardown surface: external packages this machinery produced stay on disk (deleting
+	// user-visible assets here would be data loss) -- but with the state gone nothing
+	// references them anymore. Say so instead of orphaning silently.
+	if (!ExternalSharedMeshCollection.IsNull() || !ExternalSharedLevelCollection.IsNull())
+	{
+		UE_LOG(LogPCGEx, Warning,
+		       TEXT("'%s': the removed PCG Data Asset machinery state still pointed at externalized packages ('%s', '%s'). They remain on disk, now orphaned -- delete them manually, or undo, re-add PCGData entries and disable external storage first to internalize them."),
+		       Host ? *Host->GetName() : TEXT("<null>"),
+		       *ExternalSharedMeshCollection.ToSoftObjectPath().ToString(),
+		       *ExternalSharedLevelCollection.ToSoftObjectPath().ToString());
 	}
 }
 

--- a/Source/PCGExCollections/Public/Collections/PCGExOmniCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExOmniCollection.h
@@ -80,16 +80,10 @@ public:
 	UPROPERTY(EditAnywhere, Instanced, Category = "Settings|Global", meta=(DisplayName="Type Machinery"))
 	TArray<TObjectPtr<UPCGExCollectionTypeState>> TypeStates;
 
-	/** First state instance of (or derived from) StateClass; null when absent. Accessor
-	 *  semantics (one-directional on purpose): the result IS-A StateClass, so typed access
-	 *  through the template below stays cast-safe. */
-	UPCGExCollectionTypeState* FindTypeState(const UClass* StateClass) const;
-
-	template <typename T>
-	T* FindTypeState() const
-	{
-		return static_cast<T*>(FindTypeState(T::StaticClass()));
-	}
+	/** First state instance of (or derived from) StateClass; null when absent (see base --
+	 *  accessor semantics keep the typed FindTypeState<T>() template cast-safe). */
+	using UPCGExAssetCollection::FindTypeState; // keep the base template visible
+	virtual UPCGExCollectionTypeState* FindTypeState(const UClass* StateClass) const override;
 
 	/** First state instance sharing StateClass's type SLOT (base and derived state classes
 	 *  answer the same machinery -- PCGExCollectionHelpers::MatchesTypeSlot, both directions).
@@ -163,8 +157,20 @@ public:
 	bool EDITOR_EnsureTypeSetup();
 
 	/** Single-type slice of EDITOR_EnsureTypeSetup -- what entry-add paths call so a K-row
-	 *  ingestion doesn't rescan the whole collection per row. */
-	bool EDITOR_EnsureTypeSetupForType(PCGExAssetCollection::FTypeId TypeId);
+	 *  ingestion doesn't rescan the whole collection per row. SeedSource, when given (merge /
+	 *  conversion), is offered to NEWLY created states via OnAddedToHost so they can adopt
+	 *  its settings; existing states are never touched (they get OnSeedSourceIgnored). */
+	bool EDITOR_EnsureTypeSetupForType(PCGExAssetCollection::FTypeId TypeId, const UPCGExAssetCollection* SeedSource = nullptr);
+
+	/**
+	 * State-only half of the per-type ensure. EDITOR_AppendCollections uses this MID-CALL:
+	 * states must exist early to receive the per-source seed, but installing a missing
+	 * GLOBALS block between sources would corrupt the intra-call block conflict resolution
+	 * (a later source's authored block would mistake an auto-installed CDO block for a
+	 * user-authored one and bake itself away) -- blocks are left to the tail rebuild's full
+	 * ensure, which runs after every source has had its say.
+	 */
+	bool EDITOR_EnsureTypeStateForType(PCGExAssetCollection::FTypeId TypeId, const UPCGExAssetCollection* SeedSource);
 
 	/**
 	 * Counterpart affordance (user-triggered, never automatic -- blocks/states may carry

--- a/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
+++ b/Source/PCGExCollections/Public/Collections/PCGExPCGDataAssetCollection.h
@@ -168,12 +168,19 @@ struct PCGEXCOLLECTIONS_API FPCGExPCGDataAssetCollectionEntry : public FPCGExAss
 
 /** Concrete collection for UPCGDataAsset references with optional level-sourced entries.
  *
- *  Mutualizes mesh + nested-level storage across level-sourced entries via SharedMeshCollection
- *  and SharedLevelCollection: each entry's per-level snapshots (EditorMeshContributions,
- *  EditorLevelContributions) are captured during export, then merged into the two shared
- *  collections (CompactSharedMeshFor, CompactSharedLevelFor). Per-entry ExportedDataAsset point
- *  hashes resolve through the shared collections' CollectionGUIDs at runtime, eliminating
- *  duplicated storage when entries reuse the same meshes or the same nested levels.
+ *  Mutualizes mesh + nested-level storage across level-sourced entries via the machinery
+ *  state's SharedMeshCollection and SharedLevelCollection: each entry's per-level snapshots
+ *  (EditorMeshContributions, EditorLevelContributions) are captured during export, then
+ *  merged into the two shared collections (CompactSharedMeshFor, CompactSharedLevelFor).
+ *  Per-entry ExportedDataAsset point hashes resolve through the shared collections'
+ *  CollectionGUIDs at runtime, eliminating duplicated storage when entries reuse the same
+ *  meshes or the same nested levels.
+ *
+ *  Phase C1 (per-type processor seam): the machinery storage + external-storage settings
+ *  live on an owned UPCGExPCGDataTypeState (always present, default subobject) and every
+ *  lifecycle override is a dispatch into it -- the typed collection is simply a host whose
+ *  state is guaranteed, running the exact same code path as an Omni host. Legacy members
+ *  migrate into the state on PostLoad (deprecated slots below).
  *
  *  Actor classes are kept per-entry on Entry.EmbeddedActorCollection (no cross-entry merge).
  */
@@ -292,11 +299,24 @@ public:
 	virtual void EDITOR_OnHostPostStagingRebuild(UPCGExAssetCollection* Host) override;
 	virtual void AppendCookDependencyAssetPaths(const UPCGExAssetCollection* Host, TSet<FSoftObjectPath>& OutPaths) const override;
 
-	/** Ports UPCGExPCGDataAssetCollection::PostEditChangeProperty's external-storage toggle
-	 *  reactions -- the engine delivers property edits to the instanced state FIRST, then walks
-	 *  up to the host (whose base PostEditChangeProperty triggers the staging rebuild). Without
-	 *  this, External -> Embedded on an Omni would never internalize the externalized assets. */
+	/** External-storage toggle reactions -- the engine delivers property edits to the
+	 *  instanced state FIRST, then walks up to the host (whose base PostEditChangeProperty
+	 *  triggers the staging rebuild). Without this, External -> Embedded would never
+	 *  internalize the externalized assets. */
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+
+	/** Fresh states adopt the seed source's external-storage SETTINGS (closes the merge
+	 *  gap: converting a PCGData source into an Omni used to silently fall back to
+	 *  embedded). Shared collections / External* soft refs are NOT copied -- session
+	 *  buffers and the source's own external packages respectively. */
+	virtual void OnAddedToHost(UPCGExAssetCollection* Host, const UPCGExAssetCollection* SeedSource) override;
+
+	/** Warns when the ignored source's external-storage settings differ from this state's
+	 *  (first-creator-wins is otherwise invisible). */
+	virtual void OnSeedSourceIgnored(UPCGExAssetCollection* Host, const UPCGExAssetCollection* SeedSource) override;
+
+	/** Warns when removal orphans externalized packages (never deletes them). */
+	virtual void OnRemovedFromHost(UPCGExAssetCollection* Host) override;
 #endif
 
 	/** Own-member scrub: in external mode the shared collections are session working buffers;
@@ -337,65 +357,73 @@ protected:
 	virtual bool GetTypeGlobalsInternal(const UScriptStruct* StructType, FPCGExCollectionTypeGlobals& OutGlobals) const override;
 
 public:
+	UPCGExPCGDataAssetCollection();
 
-	/** Externalize generated subobjects (ExportedDataAsset, EmbeddedActorCollection,
-	 *  SharedMeshCollection, SharedLevelCollection) as separate uassets so the collection's
-	 *  load footprint is small and per-asset loads are demand-driven by LoadPCGData. The
-	 *  externalized uassets are managed by the rebuild pipeline; overwritten on every rebuild;
-	 *  not meant to be hand-edited. */
-	UPROPERTY(EditAnywhere, Category = "External Storage")
-	bool bUseExternalAssets = false;
-
-	/** Content folder where externalized assets are written. Must be set when bUseExternalAssets
-	 *  is on; if empty, externalization is skipped with a warning and the collection falls back
-	 *  to embedded mode for that rebuild. Names are derived from the collection's asset name
-	 *  and entry index, so files are reused across rebuilds (P4-friendly overwrites). */
-	UPROPERTY(EditAnywhere, Category = "External Storage",
-		meta=(EditCondition="bUseExternalAssets", ContentDir, LongPackageName))
-	FDirectoryPath ExportFolder;
+	/**
+	 * Owned machinery state (per-type processor seam, Phase C1): external-storage settings
+	 * (bUseExternalAssets / ExportFolder) plus the shared/external collection storage the
+	 * PCGDataAsset machinery operates on. Always present (default subobject); the same
+	 * state class an Omni host instantiates per present PCGData entry type. Shared
+	 * subobjects it references stay outered to THIS collection (host package), exactly like
+	 * on an Omni host.
+	 */
+	UPROPERTY(EditAnywhere, Instanced, NoClear, Category = "External Storage", meta=(DisplayName="External Storage"))
+	TObjectPtr<UPCGExPCGDataTypeState> MachineryState;
 
 	// Entries Array
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Settings)
 	TArray<FPCGExPCGDataAssetCollectionEntry> Entries;
 
-	/** Shared mesh collection. Built by CompactSharedMeshFor() as the deduplicated union of all
-	 *  level-sourced entries' EditorMeshContributions. Outered to the collection in embedded
-	 *  mode, persists for the lifetime of the asset, and carries the stable CollectionGUID
-	 *  that gets baked into every per-entry ExportedDataAsset's "Meshes"-pin Tag_EntryIdx
-	 *  hashes. Null in external mode -- see ExternalSharedMeshCollection. */
-	UPROPERTY(Instanced)
-	TObjectPtr<UPCGExMeshCollection> SharedMeshCollection;
-
-	/** Shared level collection. Built by CompactSharedLevelFor() as the deduplicated union of all
-	 *  level-sourced entries' EditorLevelContributions (nested level instances). Same lifetime
-	 *  + GUID-stability guarantee as SharedMeshCollection. Null in external mode. */
-	UPROPERTY(Instanced)
-	TObjectPtr<UPCGExLevelCollection> SharedLevelCollection;
-
-	/** External-mode mirrors. Populated by ExternalizeSharedAndActorCollectionsFor; consumed at
-	 *  runtime indirectly via the CollectionMap pin's soft paths. Loading the parent collection
-	 *  does not pull these. */
-	UPROPERTY()
-	TSoftObjectPtr<UPCGExMeshCollection> ExternalSharedMeshCollection;
-
-	UPROPERTY()
-	TSoftObjectPtr<UPCGExLevelCollection> ExternalSharedLevelCollection;
-
 	PCGEX_ASSET_COLLECTION_BODY(FPCGExPCGDataAssetCollectionEntry)
 
 public:
+	UPCGExPCGDataTypeState* GetMachineryState() const
+	{
+		return MachineryState;
+	}
+
+	/** Machinery-state accessor through the generic host seam (see base). */
+	using UPCGExAssetCollection::FindTypeState; // keep the base template visible
+	virtual UPCGExCollectionTypeState* FindTypeState(const UClass* StateClass) const override
+	{
+		return (MachineryState && StateClass && MachineryState->GetClass()->IsChildOf(StateClass))
+			       ? MachineryState.Get()
+			       : nullptr;
+	}
+
+private:
+	// ----- Phase C1 deprecated slots (2026-07-19) -----
+	// UHT registers these under their unsuffixed names with CPF_Deprecated: legacy assets
+	// LOAD into them (tagged-property name match), saves always skip them. PostLoad moves
+	// the values into MachineryState and clears them. Remove after a deprecation cycle.
+
+	UPROPERTY()
+	bool bUseExternalAssets_DEPRECATED = false;
+
+	UPROPERTY()
+	FDirectoryPath ExportFolder_DEPRECATED;
+
+	UPROPERTY(Instanced)
+	TObjectPtr<UPCGExMeshCollection> SharedMeshCollection_DEPRECATED;
+
+	UPROPERTY(Instanced)
+	TObjectPtr<UPCGExLevelCollection> SharedLevelCollection_DEPRECATED;
+
+	UPROPERTY()
+	TSoftObjectPtr<UPCGExMeshCollection> ExternalSharedMeshCollection_DEPRECATED;
+
+	UPROPERTY()
+	TSoftObjectPtr<UPCGExLevelCollection> ExternalSharedLevelCollection_DEPRECATED;
+
+public:
 	/**
-	 * Recompact both shared collections (mesh + level) from each entry's captured editor-only
-	 * contributions, rewrite per-entry Tag_EntryIdx on the Meshes and Levels pins against the
-	 * resulting shared indices, and rebuild every entry's CollectionMap pin with the two
-	 * shared collections + the entry's EmbeddedActorCollection registered.
-	 *
-	 * Idempotent. Triggered automatically:
-	 *   - After every editor-driven staging rebuild via EDITOR_OnPostStagingRebuild.
-	 *   - At cook time via PreSave as a safety net.
-	 *   - After PostDuplicate to re-stamp hashes against the duplicate's freshly-generated
-	 *     shared-collection CollectionGUIDs.
+	 * Manual convenience: recompact both shared collections (mesh + level) from each entry's
+	 * captured editor-only contributions, rewrite per-entry Tag_EntryIdx against the
+	 * resulting shared indices, and rebuild every entry's CollectionMap pin. Idempotent.
+	 * The automatic paths (post-staging rebuild, cook-time PreSave net, PostDuplicate
+	 * re-stamp) do NOT route through this -- they dispatch through MachineryState's
+	 * lifecycle hooks directly; this exists for explicit tooling-driven recompaction.
 	 */
 	void RebuildSharedCollections();
 
@@ -452,8 +480,10 @@ public:
 	 */
 	static bool HostSupportsDataAssetMachinery(const UPCGExAssetCollection* Host);
 
-	// Lifecycle
+	// Lifecycle -- every override below is a dispatch into MachineryState (the state runs
+	// the same host-agnostic cores an Omni host drives; see UPCGExPCGDataTypeState).
 
+	virtual void PostLoad() override;
 	virtual void Serialize(FArchive& Ar) override;
 	virtual void PostDuplicate(bool bDuplicateForPIE) override;
 	virtual void PreSave(FObjectPreSaveContext ObjectSaveContext) override;
@@ -461,7 +491,6 @@ public:
 #if WITH_EDITOR
 	virtual void EDITOR_OnPostStagingRebuild() override;
 	virtual void EDITOR_AddBrowserSelectionInternal(const TArray<FAssetData>& InAssetData) override;
-	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 
 	/**
 	 * Cook-path override -- adds the references that GetAssetPaths intentionally omits
@@ -477,21 +506,8 @@ public:
 #endif
 
 private:
-	/** Compose the machinery state view from this collection's own members. */
-	FPCGExPCGDataAssetMachinery MakeMachinery();
-
-	/** True when external storage is both requested and configurable. ExportFolder is required
-	 *  in external mode; an empty folder silently falls back to embedded for that rebuild. */
-	bool IsExternalActive() const
-	{
-		return bUseExternalAssets && !ExportFolder.Path.IsEmpty();
-	}
-
-	/** Pull every externalized subobject back into this package and null the soft refs.
-	 *  Used on the External -> Embedded toggle (PostEditChangeProperty). */
-	void InternalizeSubobjects();
-
 	/** Manual utility: editor-save every external package this collection produced.
-	 *  Deliberately NOT called from PreSave -- see the cook rationale there. */
+	 *  Deliberately NOT called from PreSave -- see the cook rationale in
+	 *  UPCGExPCGDataTypeState::OnHostPreSave. */
 	void SaveExternalPackages();
 };

--- a/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
+++ b/Source/PCGExCollections/Public/Core/PCGExAssetCollection.h
@@ -28,6 +28,7 @@ struct FAssetData;
 
 class UPCGExAssetCollection;
 class UPCGExCollectionStagingPipeline;
+class UPCGExCollectionTypeState;
 
 namespace PCGExAssetCollection
 {
@@ -713,6 +714,24 @@ public:
 	virtual bool SupportsTypeMachinery(PCGExAssetCollection::FTypeId TypeId) const
 	{
 		return IsType(TypeId);
+	}
+
+	/**
+	 * First machinery state of (or derived from) StateClass this host owns; null when it
+	 * has none. Accessor semantics (one-directional IsChildOf on purpose): the result IS-A
+	 * StateClass, so the typed template below stays cast-safe. Hosts with per-type
+	 * machinery override this (Omni: TypeStates array; typed collections: their owned
+	 * state) -- the generic way to reach a host's machinery state without concrete casts.
+	 */
+	virtual UPCGExCollectionTypeState* FindTypeState(const UClass* StateClass) const
+	{
+		return nullptr;
+	}
+
+	template <typename T>
+	T* FindTypeState() const
+	{
+		return static_cast<T*>(FindTypeState(T::StaticClass()));
 	}
 
 #pragma endregion

--- a/Source/PCGExCollections/Public/Core/PCGExCollectionTypeState.h
+++ b/Source/PCGExCollections/Public/Core/PCGExCollectionTypeState.h
@@ -67,5 +67,36 @@ public:
 	virtual void AppendCookDependencyAssetPaths(const UPCGExAssetCollection* Host, TSet<FSoftObjectPath>& OutPaths) const
 	{
 	}
+
+	/**
+	 * Called once, right after a host creates this state (EnsureTypeSetup, or an explicit
+	 * ensure during merge/convert). SeedSource is the collection whose entries prompted the
+	 * creation when there is one (merge/conversion source; null for plain entry adds) --
+	 * states may adopt its settings here. NEVER called on states that already exist: an
+	 * existing state is the user's and always wins (same behavior-wins policy as
+	 * globals-block merging).
+	 */
+	virtual void OnAddedToHost(UPCGExAssetCollection* Host, const UPCGExAssetCollection* SeedSource)
+	{
+	}
+
+	/**
+	 * Called instead of OnAddedToHost when an ensure-with-seed found this state already
+	 * present (merge/conversion offered SeedSource, the existing state won). Implementations
+	 * should surface meaningful conflicts -- e.g. warn when the ignored source carried
+	 * different external-storage settings -- so the first-creator-wins policy is visible.
+	 */
+	virtual void OnSeedSourceIgnored(UPCGExAssetCollection* Host, const UPCGExAssetCollection* SeedSource)
+	{
+	}
+
+	/**
+	 * Called right before a host removes this state (EDITOR_CleanupUnusedTypeSetup) --
+	 * last chance to release or surface owned resources (e.g. warn about externalized
+	 * packages that will orphan). Removal proceeds regardless.
+	 */
+	virtual void OnRemovedFromHost(UPCGExAssetCollection* Host)
+	{
+	}
 #endif
 };


### PR DESCRIPTION
- Refactor collection type machinery from transient on-demand creation to persistent state objects owned by hosts. PCGDataAsset machinery now lives on an always-present MachineryState subobject rather than being created transiently, enabling proper state adoption during merge/conversion and lifecycle visibility.

Key changes:
- TypeStates become persistent subobjects with lifecycle callbacks (OnAddedToHost, OnSeedSourceIgnored, OnRemovedFromHost)
- PCGDataAsset machinery registration moves from OmniCollection to its own module (colocated with the type)
- Merge/conversion sources can seed new states' external-storage settings via OnAddedToHost
- Per-type state ensure splits into state-only EDITOR_EnsureTypeStateForType (mid-merge) and full setup (post-merge)
- Legacy machinery members deprecated with PostLoad migration path
- All lifecycle overrides dispatch through owned state instead of implementing machinery directly